### PR TITLE
[階層付きラジオボタン]2つ目以降の選択枝の縦位置がずれている問題を修正

### DIFF
--- a/src/views/Registration.css
+++ b/src/views/Registration.css
@@ -239,6 +239,6 @@ div.radio-item-div {
 
 /* 階層付きラジオボタンのlabel */
 label.radio-label {
-  margin-top: 5px;
+  margin-top: 5px !important;
   margin-bottom: 0px;
 }


### PR DESCRIPTION
階層付きラジオボタンにした場合、横並びにした選択枝の縦位置が1つ目と2つ目以降で異なる問題を修正
![image](https://user-images.githubusercontent.com/101262997/185278104-b9c0517d-74e4-43c8-a4ff-11a483c72507.png)