### PR TITLE
[スキーマ管理]継承スキーマの表示暫定対応

### DIFF
--- a/src/components/Schemamanager/SchemaTree.tsx
+++ b/src/components/Schemamanager/SchemaTree.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import React from 'react';
+import React, { useCallback } from 'react';
 import { ExpandMore, ChevronRight } from '@mui/icons-material';
 import CustomTreeItem from './CustomTreeItem';
 
@@ -10,15 +10,24 @@ export type treeSchema = {
   schema_title: string;
   subschema: treeSchema[];
   childschema: treeSchema[];
+  inheritschema: treeSchema[];
 };
 
 export const SCHEMA_TYPE = {
   SUBSCHEMA: 0,
   CHILDSCHEMA: 1,
+  INHERITSCHEMA: 2,
 };
 
-const collapseIcon = [<ExpandMore />, <ExpandMore />];
-const expandIcon = [<ChevronRight />, <ChevronRight />];
+const collapseIcon = [<ExpandMore />, <ExpandMore />, <ExpandMore />];
+const expandIcon = [<ChevronRight />, <ChevronRight />, <ChevronRight />];
+
+const titleGenerator = (schemaType: number, title: string) => {
+  let prefix = '';
+  if (schemaType === SCHEMA_TYPE.SUBSCHEMA) prefix = '*';
+  else if (schemaType === SCHEMA_TYPE.INHERITSCHEMA) prefix = '[継承]';
+  return `${prefix}${title}`;
+};
 
 export const makeTree = (props: {
   schemas: treeSchema[];
@@ -37,18 +46,18 @@ export const makeTree = (props: {
       {schemas.map((item: treeSchema) => (
         <CustomTreeItem
           nodeId={item.schema_id.toString()}
-          label={
-            schemaType === SCHEMA_TYPE.SUBSCHEMA
-              ? `*${item.schema_title}`
-              : item.schema_title
-          }
+          label={titleGenerator(schemaType, item.schema_title)}
           collapseIcon={
-            item.subschema.length + item.childschema.length > 0 &&
-            collapseIcon[schemaType]
+            item.subschema.length +
+              item.childschema.length +
+              item.inheritschema.length >
+              0 && collapseIcon[schemaType]
           }
           expandIcon={
-            item.subschema.length + item.childschema.length > 0 &&
-            expandIcon[schemaType]
+            item.subschema.length +
+              item.childschema.length +
+              item.inheritschema.length >
+              0 && expandIcon[schemaType]
           }
           onClick={(e) => {
             handleTreeItemClick(e, item.schema_id.toString());
@@ -63,6 +72,11 @@ export const makeTree = (props: {
             schemas: item.childschema,
             handleTreeItemClick,
             schemaType: SCHEMA_TYPE.CHILDSCHEMA,
+          })}
+          {makeTree({
+            schemas: item.inheritschema,
+            handleTreeItemClick,
+            schemaType: SCHEMA_TYPE.INHERITSCHEMA,
           })}
         </CustomTreeItem>
       ))}

--- a/src/store/schemaDataReducer.ts
+++ b/src/store/schemaDataReducer.ts
@@ -20,6 +20,7 @@ export type JesgoDocumentSchema = {
   schema_primary_id: number;
   subschema_default: number[];
   child_schema_default: number[];
+  inherit_schema_default: number[];
 };
 
 export interface schemaDataState {

--- a/src/views/SchemaManager.css
+++ b/src/views/SchemaManager.css
@@ -27,14 +27,16 @@
 }
 
 div.schema-tree {
-  width: 20rem;
+  width: 24rem;
   max-height: 100%;
+  min-height: 1.5rem;
   overflow-y: auto;
 }
 
 fieldset.schema-tree {
-  min-width: 300px;
-  max-height: calc(100vh - 140px);
+  min-width: 25.5rem;
+  max-height: calc(100vh - 11rem);
+  min-height: 14.25rem;
 }
 
 div.schema-detail {

--- a/src/views/SchemaManager.tsx
+++ b/src/views/SchemaManager.tsx
@@ -61,6 +61,14 @@ const SchemaManager = () => {
     useState<parentSchemaList>();
   const [childSchemaList, setChildSchemaList] = useState<schemaWithValid[]>([]);
   const [subSchemaList, setSubSchemaList] = useState<schemaWithValid[]>([]);
+
+  const [inheritSchemaList, setInheritSchemaList] = useState<schemaWithValid[]>(
+    []
+  );
+
+  const [selectedBaseSchemaInfo, setSelectedBaseSchemaInfo] =
+    useState<JesgoDocumentSchema>();
+
   const [tree, setTree] = useState<treeSchema[]>([]);
   const dispatch = useDispatch();
 
@@ -143,6 +151,20 @@ const SchemaManager = () => {
         });
       }
       setChildSchemaList(currentChildSchemaList);
+
+      // 継承スキーマ
+      // TODO: 本来は継承/回帰関係にあるスキーマをすべて表示する
+      const unionInheritSchemaList = lodash.union(
+        schema.inherit_schema,
+        schema.inherit_schema_default
+      );
+
+      const tmpInheritSchemaList = unionInheritSchemaList.map((inhId, i) => ({
+        valid: i + 1 <= schema.inherit_schema.length,
+        schema: GetSchemaInfo(inhId)!,
+      }));
+
+      setInheritSchemaList(tmpInheritSchemaList);
     }
 
     setSelectedSchemaParentInfo(GetParentSchemas(Number(selectedSchema)));
@@ -221,6 +243,20 @@ const SchemaManager = () => {
       // 有効子スキーマリストと編集前のスキーマリストが異なれば更新をかける
       if (!lodash.isEqual(tempChildSchemaList, baseSchemaInfo.child_schema)) {
         baseSchemaInfo.child_schema = tempChildSchemaList;
+        isChange = true;
+      }
+
+      // 継承スキーマ
+      const tempInheritSchemaList: number[] = [];
+      for (let i = 0; i < inheritSchemaList.length; i++) {
+        if (inheritSchemaList[i].valid) {
+          tempInheritSchemaList.push(inheritSchemaList[i].schema.schema_id);
+        }
+      }
+      if (
+        !lodash.isEqual(tempInheritSchemaList, baseSchemaInfo.inherit_schema)
+      ) {
+        baseSchemaInfo.inherit_schema = tempInheritSchemaList;
         isChange = true;
       }
     }
@@ -314,6 +350,16 @@ const SchemaManager = () => {
     setIsLoading(false);
   };
 
+  // 基底スキーマ情報更新
+  useEffect(() => {
+    if (selectedSchemaInfo && selectedSchemaInfo.base_schema) {
+      const baseInfo = GetSchemaInfo(selectedSchemaInfo.base_schema);
+      setSelectedBaseSchemaInfo(baseInfo);
+    } else {
+      setSelectedBaseSchemaInfo(undefined);
+    }
+  }, [selectedSchemaInfo]);
+
   const updateSchema = async () => {
     // 更新用スキーマリストの初期値として変更済親スキーマのリストを取得(変更がない場合は空配列)
     const updateSchemaList = getNeedUpdateParents();
@@ -342,6 +388,15 @@ const SchemaManager = () => {
         }
         baseSchemaInfo.child_schema = tempChildSchemaList;
 
+        // 継承スキーマ
+        const tempInheritSchemaList: number[] = [];
+        for (let i = 0; i < inheritSchemaList.length; i++) {
+          if (inheritSchemaList[i].valid) {
+            tempInheritSchemaList.push(inheritSchemaList[i].schema.schema_id);
+          }
+        }
+        baseSchemaInfo.inherit_schema = tempInheritSchemaList;
+
         updateSchemaList.push(baseSchemaInfo);
       }
     }
@@ -356,6 +411,7 @@ const SchemaManager = () => {
     if (confirm('初期設定を読み込みますか？')) {
       const tempSubSchemaList: schemaWithValid[] = [];
       const tempChildSchemaList: schemaWithValid[] = [];
+      const tempInheritSchemaList: schemaWithValid[] = [];
       if (selectedSchemaInfo !== undefined) {
         // サブスキーマを初期に戻す
         // eslint-disable-next-line no-restricted-syntax
@@ -377,8 +433,19 @@ const SchemaManager = () => {
           });
         }
 
+        // 継承スキーマを初期に戻す
+        // eslint-disable-next-line no-restricted-syntax
+        for (const schemaId of selectedSchemaInfo.inherit_schema_default) {
+          tempInheritSchemaList.push({
+            valid: true,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            schema: GetSchemaInfo(schemaId)!,
+          });
+        }
+
         setSubSchemaList(tempSubSchemaList);
         setChildSchemaList(tempChildSchemaList);
+        setInheritSchemaList(tempInheritSchemaList);
       }
     }
     // いいえであれば何もしない
@@ -400,11 +467,13 @@ const SchemaManager = () => {
   const CHECK_TYPE = {
     SUBSCHEMA: 0,
     CHILDSCHEMA: 1,
+    INHERITSCHEMA: 2,
   };
 
   const RELATION_TYPE = {
     PARENT: 0,
     CHILD: 1,
+    INHERIT: 2,
   };
   // チェックボックス状態変更
   const handleCheckClick = (relation: number, type: number, v = ''): void => {
@@ -463,6 +532,17 @@ const SchemaManager = () => {
         }
         setChildSchemaList(copySchemaList);
       }
+    } else if (relation === RELATION_TYPE.INHERIT) {
+      // 継承スキーマの場合
+      const copySchemaList = lodash.cloneDeep(inheritSchemaList);
+      // eslint-disable-next-line
+      for (let i = 0; i < copySchemaList.length; i++) {
+        const obj = copySchemaList[i];
+        if (obj.schema.schema_id === Number(v)) {
+          obj.valid = !obj.valid;
+        }
+      }
+      setInheritSchemaList(copySchemaList);
     }
   };
 
@@ -625,9 +705,20 @@ const SchemaManager = () => {
                         <span>継承スキーマ ： </span>
                         <Checkbox
                           className="show-flg-checkbox"
-                          checked={false}
-                          disabled={false}
+                          checked={!!selectedSchemaInfo.base_schema}
+                          readOnly
                         />
+                      </div>
+                      <div className="caption-and-block-long">
+                        <span>基底スキーマ ： </span>
+                        <span>
+                          {selectedBaseSchemaInfo &&
+                            selectedBaseSchemaInfo.title +
+                              (selectedBaseSchemaInfo.subtitle.length > 0
+                                ? ` ${selectedBaseSchemaInfo.subtitle}`
+                                : '')}
+                          {!selectedBaseSchemaInfo && '(なし)'}
+                        </span>
                       </div>
                       {/* TODO: スキーマダウンロードボタンサンプル */}
                       {/* <div>
@@ -711,6 +802,25 @@ const SchemaManager = () => {
                           />
                         </div>
                       </p>
+                    </fieldset>
+                    <fieldset className="schema-manager-legend">
+                      <legend>継承スキーマ</legend>
+                      <div>
+                        <p>
+                          <div className="caption-and-block">
+                            <span />
+                            <DndSortableTable
+                              checkType={[
+                                RELATION_TYPE.INHERIT,
+                                CHECK_TYPE.INHERITSCHEMA,
+                              ]}
+                              schemaList={inheritSchemaList}
+                              handleCheckClick={handleCheckClick}
+                              isDragDisabled
+                            />
+                          </div>
+                        </p>
+                      </div>
                     </fieldset>
                     <div className="SchemaManagerSaveButtonGroup">
                       <Button


### PR DESCRIPTION
スキーマ管理画面における継承スキーマの表示(暫定対応)
**バックエンド側も修正があります**

### 対応内容
- ツリーのサブスキーマ、子スキーマの下に継承スキーマの表示を追加
	- 継承スキーマはツリー上`[継承]`のプレフィックスを付ける
- 親(継承元)スキーマから継承先スキーマの表示ON/OFF切り替え可能
- 継承スキーマ選択時、基底スキーマ名の表示を追加

### 未実装
- 継承スキーマの並び替え
- 継承スキーマを基底スキーマへ格上げ可能にする対応