### PR TITLE
スキーマダウンロード機能追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "babel-loader": "^8.2.3",
         "clsx": "^1.2.1",
         "express": "^4.17.1",
+        "file-saver": "^2.0.5",
         "jsonpointer": "^5.0.0",
         "lodash": "^4.17.21",
         "react": "^17.0.2",
@@ -43,6 +44,7 @@
         "webpack": "^5.64.4"
       },
       "devDependencies": {
+        "@types/file-saver": "^2.0.5",
         "@types/lodash": "^4.14.178",
         "@types/react-csv": "^1.1.2",
         "@typescript-eslint/eslint-plugin": "^5.12.1",
@@ -2285,6 +2287,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
     },
+    "node_modules/@types/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+      "dev": true
+    },
     "node_modules/@types/history": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
@@ -4505,6 +4513,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -9411,6 +9424,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
     },
+    "@types/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
+      "dev": true
+    },
     "@types/history": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz",
@@ -11133,6 +11152,11 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-loader": "^8.2.3",
     "clsx": "^1.2.1",
     "express": "^4.17.1",
+    "file-saver": "^2.0.5",
     "jsonpointer": "^5.0.0",
     "lodash": "^4.17.21",
     "react": "^17.0.2",
@@ -48,6 +49,7 @@
     "webpack": "^5.64.4"
   },
   "devDependencies": {
+    "@types/file-saver": "^2.0.5",
     "@types/lodash": "^4.14.178",
     "@types/react-csv": "^1.1.2",
     "@typescript-eslint/eslint-plugin": "^5.12.1",

--- a/src/views/SchemaManager.tsx
+++ b/src/views/SchemaManager.tsx
@@ -9,7 +9,7 @@ import TreeView from '@mui/lab/TreeView';
 import Box from '@mui/material/Box';
 import lodash from 'lodash';
 import { useDispatch } from 'react-redux';
-import { saveAs } from "file-saver";
+import { saveAs } from 'file-saver';
 import CustomTreeItem from '../components/Schemamanager/CustomTreeItem';
 import { UserMenu } from '../components/common/UserMenu';
 import { SystemMenu } from '../components/common/SystemMenu';
@@ -712,18 +712,25 @@ const SchemaManager = () => {
                           className="normal-button nomargin"
                           title="スキーマファイルをダウンロードします"
                           onClick={() => {
-                            const jsonStr = JSON.stringify(selectedSchemaInfo.document_schema, null, 2);
+                            const jsonStr = JSON.stringify(
+                              selectedSchemaInfo.document_schema,
+                              null,
+                              2
+                            );
                             const blob = new Blob([jsonStr], {
                               type: 'application/json',
-                            })
+                            });
                             let fileName = '';
-                            if(selectedSchemaInfo.schema_id_string) {
-                              fileName = selectedSchemaInfo.schema_id_string.replace(/^\/+|\/+$/g, '').replace(/\//g, '_');
+                            if (selectedSchemaInfo.schema_id_string) {
+                              // ファイル名はスキーマIDの先頭と末尾から"/"を除き、残りの"/"は"_"へ変換する
+                              fileName = selectedSchemaInfo.schema_id_string
+                                .replace(/^\/+|\/+$/g, '')
+                                .replace(/\//g, '_');
                             }
-                            if(fileName) {
-                              saveAs(blob, `schemafile_${fileName}.json`);
+                            if (fileName) {
+                              saveAs(blob, `${fileName}.json`);
                             } else {
-                              alert('ルートスキーマはダウンロードできません。');
+                              alert('ダウンロード不可なスキーマです。');
                             }
                           }}
                         >

--- a/src/views/SchemaManager.tsx
+++ b/src/views/SchemaManager.tsx
@@ -9,6 +9,7 @@ import TreeView from '@mui/lab/TreeView';
 import Box from '@mui/material/Box';
 import lodash from 'lodash';
 import { useDispatch } from 'react-redux';
+import { saveAs } from "file-saver";
 import CustomTreeItem from '../components/Schemamanager/CustomTreeItem';
 import { UserMenu } from '../components/common/UserMenu';
 import { SystemMenu } from '../components/common/SystemMenu';
@@ -705,17 +706,31 @@ const SchemaManager = () => {
                         </span>
                       </div>
                       {/* TODO: スキーマダウンロードボタンサンプル */}
-                      {/* <div>
+                      <div>
                         <Button
                           bsStyle="success"
-                          className="normal-button nomargin glyphicon glyphicon-download-alt"
+                          className="normal-button nomargin"
                           title="スキーマファイルをダウンロードします"
-                          onClick={schemaUpload}
+                          onClick={() => {
+                            const jsonStr = JSON.stringify(selectedSchemaInfo.document_schema, null, 2);
+                            const blob = new Blob([jsonStr], {
+                              type: 'application/json',
+                            })
+                            let fileName = '';
+                            if(selectedSchemaInfo.schema_id_string) {
+                              fileName = selectedSchemaInfo.schema_id_string.replace(/^\/+|\/+$/g, '').replace(/\//g, '_');
+                            }
+                            if(fileName) {
+                              saveAs(blob, `schemafile_${fileName}.json`);
+                            } else {
+                              alert('ルートスキーマはダウンロードできません。');
+                            }
+                          }}
                         >
                           {' '}
                           スキーマダウンロード
                         </Button>
-                      </div> */}
+                      </div>
                     </fieldset>
                     <fieldset className="schema-manager-legend">
                       <legend>上位スキーマ</legend>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,6 +1251,11 @@
   "resolved" "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz"
   "version" "0.0.50"
 
+"@types/file-saver@^2.0.5":
+  "integrity" "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ=="
+  "resolved" "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz"
+  "version" "2.0.5"
+
 "@types/history@*":
   "integrity" "sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ=="
   "resolved" "https://registry.npmjs.org/@types/history/-/history-4.7.9.tgz"
@@ -2658,6 +2663,11 @@
   "version" "6.0.1"
   dependencies:
     "flat-cache" "^3.0.4"
+
+"file-saver@^2.0.5":
+  "integrity" "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+  "resolved" "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz"
+  "version" "2.0.5"
 
 "fill-range@^7.0.1":
   "integrity" "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ=="


### PR DESCRIPTION
#135 の対応
- スキーマ情報部にダウンロードボタン追加
- 読み込み済みのschema_documentをJSON.stringifyで整形した文字列を生成し、ダウンロードさせる(バックエンド未使用)
- ルートスキーマ(JESGOシステム選択時)はダウンロード不可
- ダウンロードするファイル名は`スキーマID.json`