### PR TITLE
作成済みドキュメントに後から追加されたサブスキーマを手動で登録できるようにする対応

### DIFF
--- a/src/components/CaseRegistration/Loading.tsx
+++ b/src/components/CaseRegistration/Loading.tsx
@@ -4,7 +4,7 @@ import ReactLoading from 'react-loading';
 // ローディング表示
 const Loading = () => {
   const style: { [key: string]: string } = {
-    position: 'absolute',
+    position: 'fixed',
     left: '0',
     top: '0',
     width: '100%',

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -105,7 +105,6 @@ const PanelSchema = React.memo((props: Props) => {
     useState<boolean>(false);
 
   const dispatch = useDispatch();
-  const { state } = useLocation();
 
   const {
     document_schema: documentSchema,
@@ -115,7 +114,7 @@ const PanelSchema = React.memo((props: Props) => {
   const customSchema = CustomSchema({ orgSchema: documentSchema, formData }); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
   const isTab = customSchema[Const.EX_VOCABULARY.UI_SUBSCHEMA_STYLE] === 'tab';
 
-  // unique=falseの追加可能なサブスキーマ
+  // unique=falseの追加可能なサブスキーマまたは未作成サブスキーマ
   const addableSubSchemaIds = useMemo(() => {
     const retIds: number[] = [];
     if (subschema.length > 0) {
@@ -124,7 +123,10 @@ const PanelSchema = React.memo((props: Props) => {
         if (info) {
           if (
             (info.document_schema[Const.EX_VOCABULARY.UNIQUE] ?? false) ===
-            false
+              false ||
+            !dispSubSchemaIds.find(
+              (p) => p.deleted === false && p.schemaId === info.schema_id
+            )
           ) {
             retIds.push(id);
           }
@@ -132,7 +134,7 @@ const PanelSchema = React.memo((props: Props) => {
       });
     }
     return retIds;
-  }, [subschema]);
+  }, [subschema, dispSubSchemaIds]);
 
   // console.log('---[PanelSchema]schemaInfo---');
   // console.log(schemaInfo);

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -104,7 +104,7 @@ const RootSchema = React.memo((props: Props) => {
   } = schemaInfo;
   const customSchema = CustomSchema({ orgSchema: documentSchema, formData }); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
 
-  // unique=falseの追加可能なサブスキーマ
+  // unique=falseの追加可能なサブスキーマまたは未作成サブスキーマ
   const addableSubSchemaIds = useMemo(() => {
     const retIds: number[] = [];
     if (subschema.length > 0) {
@@ -113,7 +113,10 @@ const RootSchema = React.memo((props: Props) => {
         if (info) {
           if (
             (info.document_schema[Const.EX_VOCABULARY.UNIQUE] ?? false) ===
-            false
+              false ||
+            !dispSubSchemaIds.find(
+              (p) => p.deleted === false && p.schemaId === info.schema_id
+            )
           ) {
             retIds.push(id);
           }
@@ -121,7 +124,7 @@ const RootSchema = React.memo((props: Props) => {
       });
     }
     return retIds;
-  }, [subschema]);
+  }, [subschema, dispSubSchemaIds]);
 
   // サブスキーマとサブスキーマから派生できる継承スキーマ一覧取得
   const subSchemaAndInherit = useMemo(() => {

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -77,33 +77,6 @@ const TabSchema = React.memo((props: Props) => {
     setUpdateFormData,
   } = props;
 
-  // schemaIdをもとに情報を取得
-  const schemaInfo = GetSchemaInfo(schemaId) as JesgoDocumentSchema;
-  const {
-    document_schema: documentSchema,
-    subschema,
-    child_schema: childSchema,
-  } = schemaInfo;
-
-  // unique=falseの追加可能なサブスキーマ
-  const addableSubSchemaIds = useMemo(() => {
-    const retIds: number[] = [];
-    if (subschema.length > 0) {
-      subschema.forEach((id) => {
-        const info = GetSchemaInfo(id);
-        if (info) {
-          if (
-            (info.document_schema[Const.EX_VOCABULARY.UNIQUE] ?? false) ===
-            false
-          ) {
-            retIds.push(id);
-          }
-        }
-      });
-    }
-    return retIds;
-  }, [subschema]);
-
   // 表示中のchild_schema
   const [dispChildSchemaIds, setDispChildSchemaIds] = useState<
     dispSchemaIdAndDocumentIdDefine[]
@@ -127,6 +100,36 @@ const TabSchema = React.memo((props: Props) => {
   // 子ドキュメントの更新有無
   const [updateChildFormData, setUpdateChildFormData] =
     useState<boolean>(false);
+
+  // schemaIdをもとに情報を取得
+  const schemaInfo = GetSchemaInfo(schemaId) as JesgoDocumentSchema;
+  const {
+    document_schema: documentSchema,
+    subschema,
+    child_schema: childSchema,
+  } = schemaInfo;
+
+  // unique=falseの追加可能なサブスキーマまたは未作成サブスキーマ
+  const addableSubSchemaIds = useMemo(() => {
+    const retIds: number[] = [];
+    if (subschema.length > 0) {
+      subschema.forEach((id) => {
+        const info = GetSchemaInfo(id);
+        if (info) {
+          if (
+            (info.document_schema[Const.EX_VOCABULARY.UNIQUE] ?? false) ===
+              false ||
+            !dispSubSchemaIds.find(
+              (p) => p.deleted === false && p.schemaId === info.schema_id
+            )
+          ) {
+            retIds.push(id);
+          }
+        }
+      });
+    }
+    return retIds;
+  }, [subschema, dispSubSchemaIds]);
 
   const dispatch = useDispatch();
 


### PR DESCRIPTION
#147 関連
作成済みのドキュメントのスキーマが更新されサブスキーマが追加された場合、コントロールボタンから追加できるよう対応

- 追加するときのタブ順は最新サブスキーマでの並び順を考慮して追加する
例）
元のサブスキーマ：1,2,3　でドキュメント作成済み
スキーマ4がサブスキーマに追加され、並び順は1,2,**4**,3　となった。
上記状態でサブスキーマ4を追加すると2のタブの右(1,2,**4**,3)に追加する