### PR TITLE
ダウンロード用csvファイルの名前を変更

### DIFF
--- a/src/common/DBUtility.ts
+++ b/src/common/DBUtility.ts
@@ -38,6 +38,18 @@ export const formatDate = (dateObj: Date, separator = ''): string => {
   }
 };
 
+// 日付(Date形式)から時刻を取り出しhh:mm:ssなどの形式に変換
+export const formatTime = (dateObj: Date, separator = ''): string => {
+  try {
+    const h = `00${dateObj.getHours()}`.slice(-2);
+    const m = `00${dateObj.getMinutes()}`.slice(-2);
+    const s = `00${dateObj.getSeconds()}`.slice(-2);
+    return `${h}${separator}${m}${separator}${s}`;
+  } catch {
+    return '';
+  }
+};
+
 // 日付文字列をyyyy/MM/ddなどの形式に変換
 export const formatDateStr = (dtStr: string, separator: string): string => {
   if (!dtStr) return '';

--- a/src/views/Patients.tsx
+++ b/src/views/Patients.tsx
@@ -102,6 +102,7 @@ const Patients = () => {
   const [tableMode, setTableMode] = useState('normal');
   const [facilityName, setFacilityName] = useState('');
   const [csvData, setCsvData] = useState<object[]>([]);
+  const [csvFileName, setCsvFileName] = useState<string>('');
 
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useDispatch();
@@ -496,11 +497,19 @@ const Patients = () => {
             <CSVLink
               data={csvData}
               headers={csvHeader}
-              filename={`jesgo_patients_list_${formatDate(
-                new Date()
-              )}_${formatTime(new Date())}`}
+              filename={csvFileName}
               // eslint-disable-next-line
-              onClick={() => confirm('CSVファイルをダウンロードしますか？')}
+              onClick={() => {
+                if (confirm('CSVファイルをダウンロードしますか？')) {
+                  setCsvFileName(
+                    `jesgo_patients_list_${formatDate(new Date())}_${formatTime(
+                      new Date()
+                    )}`
+                  );
+                  return true;
+                }
+                return false;
+              }}
             >
               <Button bsStyle="success" className="normal-button">
                 CSV作成

--- a/src/views/Patients.tsx
+++ b/src/views/Patients.tsx
@@ -24,7 +24,7 @@ import { UserMenu } from '../components/common/UserMenu';
 import { SystemMenu } from '../components/common/SystemMenu';
 import { settingsFromApi } from './Settings';
 import { csvHeader, patientListCsv } from '../common/MakeCsv';
-import { formatDate } from '../common/DBUtility';
+import { formatDate, formatTime } from '../common/DBUtility';
 import { Const } from '../common/Const';
 import Loading from '../components/CaseRegistration/Loading';
 import { storeSchemaInfo } from '../components/CaseRegistration/SchemaUtility';
@@ -496,6 +496,9 @@ const Patients = () => {
             <CSVLink
               data={csvData}
               headers={csvHeader}
+              filename={`jesgo_patients_list_${formatDate(
+                new Date()
+              )}_${formatTime(new Date())}`}
               // eslint-disable-next-line
               onClick={() => confirm('CSVファイルをダウンロードしますか？')}
             >


### PR DESCRIPTION
患者リストからダウンロードしたCSVのファイル名を`jesgo_patient_list_YYYYMMDD_hhmmss.csv`(それぞれ日付と時刻)に変更。