### PR TITLE
症例登録からドキュメント出力を行うと未保存の子タブが消えてしまう問題を修正

### DIFF
--- a/src/components/CaseRegistration/FormCommonComponents.tsx
+++ b/src/components/CaseRegistration/FormCommonComponents.tsx
@@ -30,7 +30,6 @@ export const createTab = (
     React.SetStateAction<dispSchemaIdAndDocumentIdDefine[]>
   >,
   isChildSchema: boolean,
-  loadedData: SaveDataObjDefine | undefined,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
   setSaveResponse: React.Dispatch<React.SetStateAction<responseResult>>,
   subSchemaCount: number,
@@ -61,7 +60,6 @@ export const createTab = (
           documentId={info.documentId}
           dispSchemaIds={[...schemaIds]}
           setDispSchemaIds={setSchemaIds}
-          loadedData={loadedData}
           setIsLoading={setIsLoading}
           setSaveResponse={setSaveResponse}
           setSelectedTabKey={setSelectedTabKey}
@@ -90,7 +88,6 @@ export const createTabs = (
   setDispChildSchemaIds: React.Dispatch<
     React.SetStateAction<dispSchemaIdAndDocumentIdDefine[]>
   >,
-  loadedData: SaveDataObjDefine | undefined,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
   setSaveResponse: React.Dispatch<React.SetStateAction<responseResult>>,
   setErrors: React.Dispatch<React.SetStateAction<RegistrationErrors[]>>,
@@ -288,7 +285,6 @@ export const createTabs = (
             subschemaIdsNotDeleted,
             setSubschemaIds,
             false,
-            loadedData,
             setIsLoading,
             setSaveResponse,
             0,
@@ -306,7 +302,6 @@ export const createTabs = (
             dispChildSchemaIdsNotDeleted,
             setDispChildSchemaIds,
             true,
-            loadedData,
             setIsLoading,
             setSaveResponse,
             subschemaIdsNotDeleted.length,
@@ -337,7 +332,6 @@ export const createPanel = (
     React.SetStateAction<dispSchemaIdAndDocumentIdDefine[]>
   >,
   isChildSchema: boolean,
-  loadedData: SaveDataObjDefine | undefined,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
   setSaveResponse: React.Dispatch<React.SetStateAction<responseResult>>,
   setErrors: React.Dispatch<React.SetStateAction<RegistrationErrors[]>>,
@@ -357,7 +351,6 @@ export const createPanel = (
       documentId={info.documentId}
       dispSchemaIds={[...schemaIds]}
       setDispSchemaIds={setSchemaIds}
-      loadedData={loadedData}
       setIsLoading={setIsLoading}
       setSaveResponse={setSaveResponse}
       isSchemaChange={info.isSchemaChange}
@@ -382,8 +375,6 @@ export const createPanels = (
   setDispChildSchemaIds: React.Dispatch<
     React.SetStateAction<dispSchemaIdAndDocumentIdDefine[]>
   >,
-
-  loadedData: SaveDataObjDefine | undefined,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>,
   setSaveResponse: React.Dispatch<React.SetStateAction<responseResult>>,
   setErrors: React.Dispatch<React.SetStateAction<RegistrationErrors[]>>,
@@ -400,7 +391,6 @@ export const createPanels = (
         subschemaIdsNotDeleted,
         setSubschemaIds,
         false,
-        loadedData,
         setIsLoading,
         setSaveResponse,
         setErrors,
@@ -414,7 +404,6 @@ export const createPanels = (
         dispChildSchemaIdsNotDeleted,
         setDispChildSchemaIds,
         true,
-        loadedData,
         setIsLoading,
         setSaveResponse,
         setErrors,

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -36,7 +36,6 @@ type Props = {
   dispSchemaIds: dispSchemaIdAndDocumentIdDefine[];
   documentId: string;
   isChildSchema: boolean;
-  loadedData: SaveDataObjDefine | undefined;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setSaveResponse: React.Dispatch<React.SetStateAction<responseResult>>;
   isSchemaChange: boolean | undefined;
@@ -55,7 +54,6 @@ const PanelSchema = React.memo((props: Props) => {
     dispSchemaIds,
     documentId,
     isChildSchema,
-    loadedData,
     setIsLoading,
     setSaveResponse,
     isSchemaChange,
@@ -194,8 +192,7 @@ const PanelSchema = React.memo((props: Props) => {
       subschema.length > 0 &&
       (isSchemaChange ||
         isParentSchemaChange ||
-        (dispSubSchemaIds.length === 0 &&
-          (!loadedData || documentId.startsWith('K'))))
+        (dispSubSchemaIds.length === 0 && documentId.startsWith('K')))
     ) {
       dispSubSchemaIds.length = 0; // 一旦クリア
       subschema.forEach((id) => {
@@ -306,115 +303,103 @@ const PanelSchema = React.memo((props: Props) => {
 
   // DBから読み込んだデータを設定
   useEffect(() => {
-    if (loadedData) {
-      let parentDoc = loadedData.jesgo_document.find(
-        (p) => p.key === documentId
+    // 編集中のデータ
+    const editedDocuments =
+      store.getState().formDataReducer.saveData.jesgo_document;
+
+    let parentDoc = editedDocuments.find((p) => p.key === documentId);
+
+    if (isParentSchemaChange) {
+      // TODO: ★関数化したい
+      // データ引継ぎ済みdocumentId一覧
+      const processedDocumentIds =
+        store.getState().formDataReducer.processedDocumentIds;
+      let sourceDoc: jesgoDocumentObjDefine | undefined;
+      store.getState().formDataReducer.deletedDocuments.some((item1) =>
+        // スキーマ継承により削除されたドキュメントの中から同じスキーマIDのものを復元する
+        item1.deletedChildDocuments.some((item2) => {
+          if (
+            item2.value.schema_id === schemaId &&
+            !processedDocumentIds.has(item2.key)
+          ) {
+            sourceDoc = item2;
+            return true;
+          }
+          return false;
+        })
       );
 
-      const editedDocuments =
-        store.getState().formDataReducer.saveData.jesgo_document;
-
-      // 編集中のデータ
-      const saveParentDoc = editedDocuments.find((p) => p.key === documentId);
-      // 継承した場合は編集中のデータをセットする
-      if (saveParentDoc) {
-        parentDoc = saveParentDoc;
-      }
-
-      if (isParentSchemaChange) {
-        // TODO: ★関数化したい
-        // データ引継ぎ済みdocumentId一覧
-        const processedDocumentIds =
-          store.getState().formDataReducer.processedDocumentIds;
-        let sourceDoc: jesgoDocumentObjDefine | undefined;
-        store.getState().formDataReducer.deletedDocuments.some((item1) =>
-          // スキーマ継承により削除されたドキュメントの中から同じスキーマIDのものを復元する
-          item1.deletedChildDocuments.some((item2) => {
-            if (
-              item2.value.schema_id === schemaId &&
-              !processedDocumentIds.has(item2.key)
-            ) {
-              sourceDoc = item2;
-              return true;
-            }
-            return false;
-          })
-        );
-
-        if (sourceDoc) {
-          parentDoc = sourceDoc;
-          dispatch({
-            type: 'DATA_TRANSFER_PROCESSED',
-            processedDocId: sourceDoc.key,
-          });
-        }
-      }
-
-      if (parentDoc) {
-        setFormData(parentDoc.value.document);
+      if (sourceDoc) {
+        parentDoc = sourceDoc;
         dispatch({
-          type: 'INPUT',
-          schemaId,
-          formData: parentDoc.value.document,
-          documentId,
-          isUpdateInput: false,
+          type: 'DATA_TRANSFER_PROCESSED',
+          processedDocId: sourceDoc.key,
+        });
+      }
+    }
+
+    if (parentDoc) {
+      setFormData(parentDoc.value.document);
+      dispatch({
+        type: 'INPUT',
+        schemaId,
+        formData: parentDoc.value.document,
+        documentId,
+        isUpdateInput: false,
+      });
+
+      const childDocuments = parentDoc.value.child_documents;
+
+      // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
+      if (childDocuments.length > 0) {
+        childDocuments.forEach((childDocId) => {
+          const childDoc = editedDocuments.find((p) => p.key === childDocId);
+          if (childDoc) {
+            const item: dispSchemaIdAndDocumentIdDefine = {
+              documentId: childDoc.key,
+              schemaId: childDoc.value.schema_id,
+              deleted: childDoc.value.deleted,
+              compId: childDoc.compId,
+              title: GetSchemaTitle(childDoc.value.schema_id),
+            };
+
+            const cDocSchemaInfo = GetSchemaInfo(childDoc.value.schema_id);
+
+            // サブスキーマに追加
+            // unique=falseのサブスキーマの場合もサブスキーマに追加する
+            if (
+              subschema.length > 0 &&
+              (!dispSubSchemaIds.find(
+                (p) => p.schemaId === childDoc.value.schema_id
+              ) ||
+                addableSubSchemaIds.includes(childDoc.value.schema_id)) &&
+              subSchemaAndInherit.includes(childDoc.value.schema_id)
+            ) {
+              dispSubSchemaIds.push(item);
+            } else if (
+              cDocSchemaInfo?.base_schema &&
+              addableSubSchemaIds.includes(cDocSchemaInfo.base_schema)
+            ) {
+              // 継承元のスキーマがサブスキーマの場合もサブスキーマに追加
+              dispSubSchemaIds.push(item);
+            } else {
+              // childスキーマに追加
+              dispChildSchemaIds.push(item);
+            }
+          }
         });
 
-        const childDocuments = parentDoc.value.child_documents;
+        SetSameSchemaTitleNumbering(dispSubSchemaIds, dispChildSchemaIds);
 
-        // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
-        if (childDocuments.length > 0) {
-          childDocuments.forEach((childDocId) => {
-            const childDoc =
-              editedDocuments.find((p) => p.key === childDocId) ||
-              loadedData.jesgo_document.find((p) => p.key === childDocId);
-            if (childDoc) {
-              const item: dispSchemaIdAndDocumentIdDefine = {
-                documentId: childDoc.key,
-                schemaId: childDoc.value.schema_id,
-                deleted: childDoc.value.deleted,
-                compId: childDoc.compId,
-                title: GetSchemaTitle(childDoc.value.schema_id),
-              };
-
-              const cDocSchemaInfo = GetSchemaInfo(childDoc.value.schema_id);
-
-              // サブスキーマに追加
-              // unique=falseのサブスキーマの場合もサブスキーマに追加する
-              if (
-                subschema.length > 0 &&
-                (!dispSubSchemaIds.find(
-                  (p) => p.schemaId === childDoc.value.schema_id
-                ) ||
-                  addableSubSchemaIds.includes(childDoc.value.schema_id)) &&
-                subSchemaAndInherit.includes(childDoc.value.schema_id)
-              ) {
-                dispSubSchemaIds.push(item);
-              } else if (
-                cDocSchemaInfo?.base_schema &&
-                addableSubSchemaIds.includes(cDocSchemaInfo.base_schema)
-              ) {
-                // 継承元のスキーマがサブスキーマの場合もサブスキーマに追加
-                dispSubSchemaIds.push(item);
-              } else {
-                // childスキーマに追加
-                dispChildSchemaIds.push(item);
-              }
-            }
-          });
-
-          SetSameSchemaTitleNumbering(dispSubSchemaIds, dispChildSchemaIds);
-
-          if (dispSubSchemaIds.length > 0) {
-            setDispSubSchemaIds([...dispSubSchemaIds]);
-          }
-          if (dispChildSchemaIds.length > 0) {
-            setDispChildSchemaIds([...dispChildSchemaIds]);
-          }
+        if (dispSubSchemaIds.length > 0) {
+          setDispSubSchemaIds([...dispSubSchemaIds]);
+        }
+        if (dispChildSchemaIds.length > 0) {
+          setDispChildSchemaIds([...dispChildSchemaIds]);
         }
       }
     }
-  }, [loadedData, documentId]);
+  }, [documentId]);
 
   // サブスキーマ
   useEffect(() => {
@@ -629,7 +614,6 @@ const PanelSchema = React.memo((props: Props) => {
             dispChildSchemaIds,
             dispChildSchemaIdsNotDeleted,
             setDispChildSchemaIds,
-            loadedData,
             setIsLoading,
             setSaveResponse,
             setErrors,
@@ -645,7 +629,6 @@ const PanelSchema = React.memo((props: Props) => {
             dispChildSchemaIds,
             dispChildSchemaIdsNotDeleted,
             setDispChildSchemaIds,
-            loadedData,
             setIsLoading,
             setSaveResponse,
             setErrors,

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -311,12 +311,11 @@ const PanelSchema = React.memo((props: Props) => {
         (p) => p.key === documentId
       );
 
+      const editedDocuments =
+        store.getState().formDataReducer.saveData.jesgo_document;
+
       // 編集中のデータ
-      const saveParentDoc = store
-        .getState()
-        .formDataReducer.saveData.jesgo_document.find(
-          (p) => p.key === documentId
-        );
+      const saveParentDoc = editedDocuments.find((p) => p.key === documentId);
       // 継承した場合は編集中のデータをセットする
       if (saveParentDoc) {
         parentDoc = saveParentDoc;
@@ -366,9 +365,9 @@ const PanelSchema = React.memo((props: Props) => {
         // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
         if (childDocuments.length > 0) {
           childDocuments.forEach((childDocId) => {
-            const childDoc = loadedData.jesgo_document.find(
-              (p) => p.key === childDocId
-            );
+            const childDoc =
+              editedDocuments.find((p) => p.key === childDocId) ||
+              loadedData.jesgo_document.find((p) => p.key === childDocId);
             if (childDoc) {
               const item: dispSchemaIdAndDocumentIdDefine = {
                 documentId: childDoc.key,

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -35,7 +35,6 @@ type Props = {
     React.SetStateAction<dispSchemaIdAndDocumentIdDefine[]>
   >;
   documentId: string;
-  loadedData: SaveDataObjDefine | undefined;
   setSelectedTabKey: React.Dispatch<React.SetStateAction<any>>;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setSaveResponse: React.Dispatch<React.SetStateAction<responseResult>>;
@@ -54,7 +53,6 @@ const RootSchema = React.memo((props: Props) => {
     dispSchemaIds,
     setDispSchemaIds,
     documentId,
-    loadedData,
     setSelectedTabKey,
     setIsLoading,
     setSaveResponse,
@@ -181,8 +179,7 @@ const RootSchema = React.memo((props: Props) => {
       // 新規または継承時
       subschema.length > 0 &&
       (isSchemaChange ||
-        (dispSubSchemaIds.length === 0 &&
-          (!loadedData || documentId.startsWith('K'))))
+        (dispSubSchemaIds.length === 0 && documentId.startsWith('K')))
     ) {
       dispSubSchemaIds.length = 0; // 一旦クリア
       subschema.forEach((id) => {
@@ -307,88 +304,76 @@ const RootSchema = React.memo((props: Props) => {
 
   // DBから読み込んだデータを設定
   useEffect(() => {
-    if (loadedData) {
-      let parentDoc = loadedData.jesgo_document.find(
-        (p) => p.key === documentId
-      );
+    // 編集中のデータ
+    const editedDocuments =
+      store.getState().formDataReducer.saveData.jesgo_document;
 
-      const editedDocuments =
-        store.getState().formDataReducer.saveData.jesgo_document;
+    const parentDoc = editedDocuments.find((p) => p.key === documentId);
 
-      // 編集中のデータ
-      const saveParentDoc = editedDocuments.find((p) => p.key === documentId);
-      // 継承した場合は編集中のデータをセットする
-      if (saveParentDoc) {
-        parentDoc = saveParentDoc;
-      }
+    if (parentDoc) {
+      setFormData(parentDoc.value.document);
+      dispatch({
+        type: 'INPUT',
+        schemaId,
+        formData: parentDoc.value.document,
+        documentId,
+        isUpdateInput: false,
+      });
 
-      if (parentDoc) {
-        setFormData(parentDoc.value.document);
-        dispatch({
-          type: 'INPUT',
-          schemaId,
-          formData: parentDoc.value.document,
-          documentId,
-          isUpdateInput: false,
+      const childDocuments = parentDoc.value.child_documents;
+
+      // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
+      if (childDocuments.length > 0) {
+        childDocuments.forEach((childDocId) => {
+          const childDoc = editedDocuments.find((p) => p.key === childDocId);
+
+          if (childDoc) {
+            const item: dispSchemaIdAndDocumentIdDefine = {
+              documentId: childDoc.key,
+              schemaId: childDoc.value.schema_id,
+              deleted: childDoc.value.deleted,
+              compId: childDoc.compId,
+              title: GetSchemaTitle(childDoc.value.schema_id),
+            };
+
+            const cDocSchemaInfo = GetSchemaInfo(childDoc.value.schema_id);
+
+            // サブスキーマに追加
+            // unique=falseのサブスキーマの場合もサブスキーマに追加する
+            if (
+              subschema.length > 0 &&
+              (!dispSubSchemaIds.find(
+                (p) => p.schemaId === childDoc.value.schema_id
+              ) ||
+                addableSubSchemaIds.includes(childDoc.value.schema_id)) &&
+              subSchemaAndInherit.includes(childDoc.value.schema_id)
+            ) {
+              dispSubSchemaIds.push(item);
+            } else if (
+              cDocSchemaInfo?.base_schema &&
+              addableSubSchemaIds.includes(cDocSchemaInfo.base_schema)
+            ) {
+              // 継承元のスキーマがサブスキーマの場合もサブスキーマに追加
+              dispSubSchemaIds.push(item);
+            } else {
+              // childスキーマに追加
+              dispChildSchemaIds.push(item);
+            }
+          }
         });
 
-        const childDocuments = parentDoc.value.child_documents;
+        // 同一スキーマ存在時のタブ名
+        SetSameSchemaTitleNumbering(dispSubSchemaIds, dispChildSchemaIds);
 
-        // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
-        if (childDocuments.length > 0) {
-          childDocuments.forEach((childDocId) => {
-            const childDoc =
-              editedDocuments.find((p) => p.key === childDocId) ||
-              loadedData.jesgo_document.find((p) => p.key === childDocId);
-
-            if (childDoc) {
-              const item: dispSchemaIdAndDocumentIdDefine = {
-                documentId: childDoc.key,
-                schemaId: childDoc.value.schema_id,
-                deleted: childDoc.value.deleted,
-                compId: childDoc.compId,
-                title: GetSchemaTitle(childDoc.value.schema_id),
-              };
-
-              const cDocSchemaInfo = GetSchemaInfo(childDoc.value.schema_id);
-
-              // サブスキーマに追加
-              // unique=falseのサブスキーマの場合もサブスキーマに追加する
-              if (
-                subschema.length > 0 &&
-                (!dispSubSchemaIds.find(
-                  (p) => p.schemaId === childDoc.value.schema_id
-                ) ||
-                  addableSubSchemaIds.includes(childDoc.value.schema_id)) &&
-                subSchemaAndInherit.includes(childDoc.value.schema_id)
-              ) {
-                dispSubSchemaIds.push(item);
-              } else if (
-                cDocSchemaInfo?.base_schema &&
-                addableSubSchemaIds.includes(cDocSchemaInfo.base_schema)
-              ) {
-                // 継承元のスキーマがサブスキーマの場合もサブスキーマに追加
-                dispSubSchemaIds.push(item);
-              } else {
-                // childスキーマに追加
-                dispChildSchemaIds.push(item);
-              }
-            }
-          });
-
-          // 同一スキーマ存在時のタブ名
-          SetSameSchemaTitleNumbering(dispSubSchemaIds, dispChildSchemaIds);
-
-          if (dispSubSchemaIds.length > 0) {
-            setDispSubSchemaIds([...dispSubSchemaIds]);
-          }
-          if (dispChildSchemaIds.length > 0) {
-            setDispChildSchemaIds([...dispChildSchemaIds]);
-          }
+        if (dispSubSchemaIds.length > 0) {
+          setDispSubSchemaIds([...dispSubSchemaIds]);
+        }
+        if (dispChildSchemaIds.length > 0) {
+          setDispChildSchemaIds([...dispChildSchemaIds]);
         }
       }
     }
-  }, [loadedData, documentId]);
+  }, [documentId]);
 
   // サブスキーマ
   useEffect(() => {
@@ -572,7 +557,6 @@ const RootSchema = React.memo((props: Props) => {
         dispChildSchemaIds,
         dispChildSchemaIdsNotDeleted,
         setDispChildSchemaIds,
-        loadedData,
         setIsLoading,
         setSaveResponse,
         setErrors,

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -312,12 +312,11 @@ const RootSchema = React.memo((props: Props) => {
         (p) => p.key === documentId
       );
 
+      const editedDocuments =
+        store.getState().formDataReducer.saveData.jesgo_document;
+
       // 編集中のデータ
-      const saveParentDoc = store
-        .getState()
-        .formDataReducer.saveData.jesgo_document.find(
-          (p) => p.key === documentId
-        );
+      const saveParentDoc = editedDocuments.find((p) => p.key === documentId);
       // 継承した場合は編集中のデータをセットする
       if (saveParentDoc) {
         parentDoc = saveParentDoc;
@@ -338,9 +337,10 @@ const RootSchema = React.memo((props: Props) => {
         // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
         if (childDocuments.length > 0) {
           childDocuments.forEach((childDocId) => {
-            const childDoc = loadedData.jesgo_document.find(
-              (p) => p.key === childDocId
-            );
+            const childDoc =
+              editedDocuments.find((p) => p.key === childDocId) ||
+              loadedData.jesgo_document.find((p) => p.key === childDocId);
+
             if (childDoc) {
               const item: dispSchemaIdAndDocumentIdDefine = {
                 documentId: childDoc.key,

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -38,7 +38,6 @@ type Props = {
   >;
   documentId: string;
   isChildSchema: boolean;
-  loadedData: SaveDataObjDefine | undefined;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setSaveResponse: React.Dispatch<React.SetStateAction<responseResult>>;
   setSelectedTabKey: React.Dispatch<React.SetStateAction<any>>;
@@ -60,7 +59,6 @@ const TabSchema = React.memo((props: Props) => {
     setDispSchemaIds,
     documentId,
     isChildSchema,
-    loadedData,
     setIsLoading,
     setSaveResponse,
     setSelectedTabKey,
@@ -193,8 +191,7 @@ const TabSchema = React.memo((props: Props) => {
       subschema.length > 0 &&
       (isSchemaChange ||
         isParentSchemaChange ||
-        (dispSubSchemaIds.length === 0 &&
-          (!loadedData || documentId.startsWith('K'))))
+        (dispSubSchemaIds.length === 0 && documentId.startsWith('K')))
     ) {
       dispSubSchemaIds.length = 0; // 一旦クリア
       subschema.forEach((id) => {
@@ -322,115 +319,103 @@ const TabSchema = React.memo((props: Props) => {
 
   // DBから読み込んだデータを設定
   useEffect(() => {
-    if (loadedData) {
-      let parentDoc = loadedData.jesgo_document.find(
-        (p) => p.key === documentId
+    // 編集中のデータ
+    const editedDocuments =
+      store.getState().formDataReducer.saveData.jesgo_document;
+
+    let parentDoc = editedDocuments.find((p) => p.key === documentId);
+
+    if (isParentSchemaChange) {
+      // TODO: ★関数化したい
+      // データ引継ぎ済みdocumentId一覧
+      const processedDocumentIds =
+        store.getState().formDataReducer.processedDocumentIds;
+      let sourceDoc: jesgoDocumentObjDefine | undefined;
+      store.getState().formDataReducer.deletedDocuments.some((item1) =>
+        // スキーマ継承により削除されたドキュメントの中から同じスキーマIDのものを復元する
+        item1.deletedChildDocuments.some((item2) => {
+          if (
+            item2.value.schema_id === schemaId &&
+            !processedDocumentIds.has(item2.key)
+          ) {
+            sourceDoc = item2;
+            return true;
+          }
+          return false;
+        })
       );
 
-      const editedDocuments =
-        store.getState().formDataReducer.saveData.jesgo_document;
-
-      // 編集中のデータ
-      const saveParentDoc = editedDocuments.find((p) => p.key === documentId);
-      // 継承した場合は編集中のデータをセットする
-      if (saveParentDoc) {
-        parentDoc = saveParentDoc;
-      }
-
-      if (isParentSchemaChange) {
-        // TODO: ★関数化したい
-        // データ引継ぎ済みdocumentId一覧
-        const processedDocumentIds =
-          store.getState().formDataReducer.processedDocumentIds;
-        let sourceDoc: jesgoDocumentObjDefine | undefined;
-        store.getState().formDataReducer.deletedDocuments.some((item1) =>
-          // スキーマ継承により削除されたドキュメントの中から同じスキーマIDのものを復元する
-          item1.deletedChildDocuments.some((item2) => {
-            if (
-              item2.value.schema_id === schemaId &&
-              !processedDocumentIds.has(item2.key)
-            ) {
-              sourceDoc = item2;
-              return true;
-            }
-            return false;
-          })
-        );
-
-        if (sourceDoc) {
-          parentDoc = sourceDoc;
-          dispatch({
-            type: 'DATA_TRANSFER_PROCESSED',
-            processedDocId: sourceDoc.key,
-          });
-        }
-      }
-
-      if (parentDoc) {
-        setFormData(parentDoc.value.document);
+      if (sourceDoc) {
+        parentDoc = sourceDoc;
         dispatch({
-          type: 'INPUT',
-          schemaId,
-          formData: parentDoc.value.document,
-          documentId,
-          isUpdateInput: false,
+          type: 'DATA_TRANSFER_PROCESSED',
+          processedDocId: sourceDoc.key,
+        });
+      }
+    }
+
+    if (parentDoc) {
+      setFormData(parentDoc.value.document);
+      dispatch({
+        type: 'INPUT',
+        schemaId,
+        formData: parentDoc.value.document,
+        documentId,
+        isUpdateInput: false,
+      });
+
+      const childDocuments = parentDoc.value.child_documents;
+
+      // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
+      if (childDocuments.length > 0) {
+        childDocuments.forEach((childDocId) => {
+          const childDoc = editedDocuments.find((p) => p.key === childDocId);
+          if (childDoc) {
+            const item: dispSchemaIdAndDocumentIdDefine = {
+              documentId: childDoc.key,
+              schemaId: childDoc.value.schema_id,
+              deleted: childDoc.value.deleted,
+              compId: childDoc.compId,
+              title: GetSchemaTitle(childDoc.value.schema_id),
+            };
+
+            const cDocSchemaInfo = GetSchemaInfo(childDoc.value.schema_id);
+
+            // サブスキーマに追加
+            // unique=falseのサブスキーマの場合もサブスキーマに追加する必要あり
+            if (
+              subschema.length > 0 &&
+              (!dispSubSchemaIds.find(
+                (p) => p.schemaId === childDoc.value.schema_id
+              ) ||
+                addableSubSchemaIds.includes(childDoc.value.schema_id)) &&
+              subSchemaAndInherit.includes(childDoc.value.schema_id)
+            ) {
+              dispSubSchemaIds.push(item);
+            } else if (
+              cDocSchemaInfo?.base_schema &&
+              addableSubSchemaIds.includes(cDocSchemaInfo.base_schema)
+            ) {
+              // 継承元のスキーマがサブスキーマの場合もサブスキーマに追加
+              dispSubSchemaIds.push(item);
+            } else {
+              // childスキーマに追加
+              dispChildSchemaIds.push(item);
+            }
+          }
         });
 
-        const childDocuments = parentDoc.value.child_documents;
+        SetSameSchemaTitleNumbering(dispSubSchemaIds, dispChildSchemaIds);
 
-        // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
-        if (childDocuments.length > 0) {
-          childDocuments.forEach((childDocId) => {
-            const childDoc =
-              editedDocuments.find((p) => p.key === childDocId) ||
-              loadedData.jesgo_document.find((p) => p.key === childDocId);
-            if (childDoc) {
-              const item: dispSchemaIdAndDocumentIdDefine = {
-                documentId: childDoc.key,
-                schemaId: childDoc.value.schema_id,
-                deleted: childDoc.value.deleted,
-                compId: childDoc.compId,
-                title: GetSchemaTitle(childDoc.value.schema_id),
-              };
-
-              const cDocSchemaInfo = GetSchemaInfo(childDoc.value.schema_id);
-
-              // サブスキーマに追加
-              // unique=falseのサブスキーマの場合もサブスキーマに追加する必要あり
-              if (
-                subschema.length > 0 &&
-                (!dispSubSchemaIds.find(
-                  (p) => p.schemaId === childDoc.value.schema_id
-                ) ||
-                  addableSubSchemaIds.includes(childDoc.value.schema_id)) &&
-                subSchemaAndInherit.includes(childDoc.value.schema_id)
-              ) {
-                dispSubSchemaIds.push(item);
-              } else if (
-                cDocSchemaInfo?.base_schema &&
-                addableSubSchemaIds.includes(cDocSchemaInfo.base_schema)
-              ) {
-                // 継承元のスキーマがサブスキーマの場合もサブスキーマに追加
-                dispSubSchemaIds.push(item);
-              } else {
-                // childスキーマに追加
-                dispChildSchemaIds.push(item);
-              }
-            }
-          });
-
-          SetSameSchemaTitleNumbering(dispSubSchemaIds, dispChildSchemaIds);
-
-          if (dispSubSchemaIds.length > 0) {
-            setDispSubSchemaIds([...dispSubSchemaIds]);
-          }
-          if (dispChildSchemaIds.length > 0) {
-            setDispChildSchemaIds([...dispChildSchemaIds]);
-          }
+        if (dispSubSchemaIds.length > 0) {
+          setDispSubSchemaIds([...dispSubSchemaIds]);
+        }
+        if (dispChildSchemaIds.length > 0) {
+          setDispChildSchemaIds([...dispChildSchemaIds]);
         }
       }
     }
-  }, [loadedData, documentId]);
+  }, [documentId]);
 
   // サブスキーマ
   useEffect(() => {
@@ -629,7 +614,6 @@ const TabSchema = React.memo((props: Props) => {
             dispChildSchemaIds,
             dispChildSchemaIdsNotDeleted,
             setDispChildSchemaIds,
-            loadedData,
             setIsLoading,
             setSaveResponse,
             setErrors,
@@ -645,7 +629,6 @@ const TabSchema = React.memo((props: Props) => {
             dispChildSchemaIds,
             dispChildSchemaIdsNotDeleted,
             setDispChildSchemaIds,
-            loadedData,
             setIsLoading,
             setSaveResponse,
             setErrors,

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -327,12 +327,11 @@ const TabSchema = React.memo((props: Props) => {
         (p) => p.key === documentId
       );
 
+      const editedDocuments =
+        store.getState().formDataReducer.saveData.jesgo_document;
+
       // 編集中のデータ
-      const saveParentDoc = store
-        .getState()
-        .formDataReducer.saveData.jesgo_document.find(
-          (p) => p.key === documentId
-        );
+      const saveParentDoc = editedDocuments.find((p) => p.key === documentId);
       // 継承した場合は編集中のデータをセットする
       if (saveParentDoc) {
         parentDoc = saveParentDoc;
@@ -382,9 +381,9 @@ const TabSchema = React.memo((props: Props) => {
         // 子ドキュメントがあればサブスキーマとchildスキーマを判定してそれぞれの配列に格納
         if (childDocuments.length > 0) {
           childDocuments.forEach((childDocId) => {
-            const childDoc = loadedData.jesgo_document.find(
-              (p) => p.key === childDocId
-            );
+            const childDoc =
+              editedDocuments.find((p) => p.key === childDocId) ||
+              loadedData.jesgo_document.find((p) => p.key === childDocId);
             if (childDoc) {
               const item: dispSchemaIdAndDocumentIdDefine = {
                 documentId: childDoc.key,

--- a/src/views/Registration.tsx
+++ b/src/views/Registration.tsx
@@ -720,7 +720,6 @@ const Registration = () => {
                             documentId={info.documentId}
                             dispSchemaIds={[...dispRootSchemaIds]}
                             setDispSchemaIds={setDispRootSchemaIds}
-                            loadedData={loadData}
                             setSelectedTabKey={setSelectedTabKey}
                             setIsLoading={setIsLoading}
                             setSaveResponse={setSaveResponse}


### PR DESCRIPTION
症例登録からのドキュメント出力時に未保存の新規追加タブ(子タブ)があると画面再描画後に子タブが消えてしまう
**原因**
子タブ再描画時の処理でDBから取得したデータ(loadedData)から復元するようになっていたため

**対応**
- storeに持っている編集中のデータから復元するよう修正
- 上記に伴い親から渡していたDBデータ(loadedData)は不要になったため削除