### PR TITLE
スキーマ継承時、子スキーマが別の親スキーマに復元されてしまう問題を修正

### DIFF
--- a/src/common/CaseRegistrationUtility.ts
+++ b/src/common/CaseRegistrationUtility.ts
@@ -939,6 +939,7 @@ export const GetBeforeInheritDocumentData = (
   schemaId: number
 ) => {
   let retDocs: jesgoDocumentObjDefine[] = [];
+  let searchDocId = parentDocId;
 
   const deletedDocuments = store.getState().formDataReducer.deletedDocuments;
 
@@ -946,12 +947,21 @@ export const GetBeforeInheritDocumentData = (
   const processedDocumentIds =
     store.getState().formDataReducer.processedDocumentIds;
 
-  if (parentDocId === '') {
+  // 親のIDが仮番の場合、旧IDを取得
+  if (parentDocId.startsWith('K')) {
+    const item = processedDocumentIds.find((p) => p[1] === parentDocId);
+    if (item) {
+      searchDocId = item[0];
+    }
+  }
+
+  if (searchDocId === '') {
     // documentIdの指定がない場合は全検索
     deletedDocuments.forEach((item) => {
       const filter = item.deletedChildDocuments.filter(
         (p) =>
-          p.value.schema_id === schemaId && !processedDocumentIds.has(p.key)
+          p.value.schema_id === schemaId &&
+          !processedDocumentIds.find((q) => q[0] === p.key)
       );
       if (filter.length > 0) {
         retDocs = filter;
@@ -960,12 +970,13 @@ export const GetBeforeInheritDocumentData = (
   } else {
     // documentIdの指定がある場合はそのdocumentIdに紐づくデータを取得
     const deletedItem = deletedDocuments.find(
-      (p) => p.parentDocumentId === parentDocId
+      (p) => p.parentDocumentId === searchDocId
     );
     if (deletedItem) {
       const baseDoc = deletedItem.deletedChildDocuments.filter(
         (p) =>
-          p.value.schema_id === schemaId && !processedDocumentIds.has(p.key)
+          p.value.schema_id === schemaId &&
+          !processedDocumentIds.find((q) => q[0] === p.key)
       );
       if (baseDoc.length > 0) {
         retDocs = baseDoc;

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -213,11 +213,8 @@ const PanelSchema = React.memo((props: Props) => {
 
           let inheritDocuments: jesgoDocumentObjDefine[] = [];
           // 継承した場合は削除したドキュメントの中から同じスキーマのドキュメントを取得
-          if (isSchemaChange) {
+          if (isSchemaChange || isParentSchemaChange) {
             inheritDocuments = GetBeforeInheritDocumentData(documentId, id);
-          } else if (isParentSchemaChange) {
-            // 親スキーマで継承されていた場合は自身のdocIdは振り直しされているので全検索する
-            inheritDocuments = GetBeforeInheritDocumentData('', id);
           }
           if (inheritDocuments.length > 0) {
             inheritDocuments.forEach((inheritItem) => {
@@ -249,10 +246,6 @@ const PanelSchema = React.memo((props: Props) => {
                 isRootSchema: false,
                 schemaInfo: itemSchemaInfo,
                 setAddedDocumentCount,
-              });
-
-              dispatch({
-                type: 'DATA_TRANSFER_PROCESSED',
                 processedDocId: inheritItem.key,
               });
             });
@@ -336,7 +329,7 @@ const PanelSchema = React.memo((props: Props) => {
           item1.deletedChildDocuments.some((item2) => {
             if (
               item2.value.schema_id === schemaId &&
-              !processedDocumentIds.has(item2.key)
+              !processedDocumentIds.find((p) => p[0] === item2.key)
             ) {
               sourceDoc = item2;
               return true;
@@ -350,6 +343,7 @@ const PanelSchema = React.memo((props: Props) => {
           dispatch({
             type: 'DATA_TRANSFER_PROCESSED',
             processedDocId: sourceDoc.key,
+            processedNewDocId: documentId,
           });
         }
       }
@@ -433,12 +427,10 @@ const PanelSchema = React.memo((props: Props) => {
       if (childSchema.length > 0) {
         const searchChildDocs: jesgoDocumentObjDefine[] = [];
         childSchema.forEach((id) => {
-          if (isSchemaChange) {
+          if (isSchemaChange || isParentSchemaChange) {
             searchChildDocs.push(
               ...GetBeforeInheritDocumentData(documentId, id)
             );
-          } else if (isParentSchemaChange) {
-            searchChildDocs.push(...GetBeforeInheritDocumentData('', id));
           }
         });
 
@@ -450,6 +442,7 @@ const PanelSchema = React.memo((props: Props) => {
               deleted: false,
               compId: '',
               title: GetSchemaTitle(doc.value.schema_id),
+              isParentSchemaChange: isParentSchemaChange || isSchemaChange,
             };
             dispChildSchemaIds.push(item);
 
@@ -464,10 +457,6 @@ const PanelSchema = React.memo((props: Props) => {
               isRootSchema: false,
               schemaInfo: GetSchemaInfo(doc.value.schema_id),
               setAddedDocumentCount,
-            });
-
-            dispatch({
-              type: 'DATA_TRANSFER_PROCESSED',
               processedDocId: doc.key,
             });
           });

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -234,10 +234,6 @@ const RootSchema = React.memo((props: Props) => {
                 isRootSchema: false,
                 schemaInfo: itemSchemaInfo,
                 setAddedDocumentCount,
-              });
-
-              dispatch({
-                type: 'DATA_TRANSFER_PROCESSED',
                 processedDocId: inheritItem.key,
               });
             });
@@ -431,10 +427,6 @@ const RootSchema = React.memo((props: Props) => {
               isRootSchema: false,
               schemaInfo: GetSchemaInfo(doc.value.schema_id),
               setAddedDocumentCount,
-            });
-
-            dispatch({
-              type: 'DATA_TRANSFER_PROCESSED',
               processedDocId: doc.key,
             });
           });

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -212,11 +212,8 @@ const TabSchema = React.memo((props: Props) => {
 
           let inheritDocuments: jesgoDocumentObjDefine[] = [];
           // 継承した場合は削除したドキュメントの中から同じスキーマのドキュメントを取得
-          if (isSchemaChange) {
+          if (isSchemaChange || isParentSchemaChange) {
             inheritDocuments = GetBeforeInheritDocumentData(documentId, id);
-          } else if (isParentSchemaChange) {
-            // 親スキーマで継承されていた場合は自身のdocIdは振り直しされているので全検索する
-            inheritDocuments = GetBeforeInheritDocumentData('', id);
           }
 
           if (inheritDocuments.length > 0) {
@@ -249,10 +246,6 @@ const TabSchema = React.memo((props: Props) => {
                 isRootSchema: false,
                 schemaInfo: itemSchemaInfo,
                 setAddedDocumentCount,
-              });
-
-              dispatch({
-                type: 'DATA_TRANSFER_PROCESSED',
                 processedDocId: inheritItem.key,
               });
             });
@@ -352,7 +345,7 @@ const TabSchema = React.memo((props: Props) => {
           item1.deletedChildDocuments.some((item2) => {
             if (
               item2.value.schema_id === schemaId &&
-              !processedDocumentIds.has(item2.key)
+              !processedDocumentIds.find((p) => p[0] === item2.key)
             ) {
               sourceDoc = item2;
               return true;
@@ -366,6 +359,7 @@ const TabSchema = React.memo((props: Props) => {
           dispatch({
             type: 'DATA_TRANSFER_PROCESSED',
             processedDocId: sourceDoc.key,
+            processedNewDocId: documentId,
           });
         }
       }
@@ -449,12 +443,10 @@ const TabSchema = React.memo((props: Props) => {
       if (childSchema.length > 0) {
         const searchChildDocs: jesgoDocumentObjDefine[] = [];
         childSchema.forEach((id) => {
-          if (isSchemaChange) {
+          if (isSchemaChange || isParentSchemaChange) {
             searchChildDocs.push(
               ...GetBeforeInheritDocumentData(documentId, id)
             );
-          } else if (isParentSchemaChange) {
-            searchChildDocs.push(...GetBeforeInheritDocumentData('', id));
           }
         });
 
@@ -466,6 +458,7 @@ const TabSchema = React.memo((props: Props) => {
               deleted: false,
               compId: '',
               title: GetSchemaTitle(doc.value.schema_id),
+              isParentSchemaChange: isParentSchemaChange || isSchemaChange,
             };
             dispChildSchemaIds.push(item);
 
@@ -480,10 +473,6 @@ const TabSchema = React.memo((props: Props) => {
               isRootSchema: false,
               schemaInfo: GetSchemaInfo(doc.value.schema_id),
               setAddedDocumentCount,
-            });
-
-            dispatch({
-              type: 'DATA_TRANSFER_PROCESSED',
               processedDocId: doc.key,
             });
           });

--- a/src/store/formDataReducer.ts
+++ b/src/store/formDataReducer.ts
@@ -65,7 +65,7 @@ export interface formDataState {
     parentDocumentId: string;
     deletedChildDocuments: jesgoDocumentObjDefine[];
   }[];
-  processedDocumentIds: Set<string>;
+  processedDocumentIds: [string, string][];
   formDataInputStates: Map<string, boolean>;
 }
 
@@ -119,6 +119,7 @@ export interface formDataAction {
   isUpdateInput: boolean;
   isNotUniqueSubSchemaAdded: boolean;
   processedDocId: string;
+  processedNewDocId: string;
 
   hasFormDataInput: boolean;
 }
@@ -183,7 +184,7 @@ const initialState: formDataState = {
   tabSelectEvent: undefined,
   selectedTabKeyName: '',
   deletedDocuments: [],
-  processedDocumentIds: new Set(),
+  processedDocumentIds: [],
   formDataInputStates: new Map(),
 };
 
@@ -455,6 +456,13 @@ const formDataReducer: Reducer<
           action.setAddedDocumentCount(copyState.addedDocumentCount);
         }
 
+        // 継承時の処理済みdocumentIdと新規で振られたdocumentIdを紐づける
+        if (action.processedDocId) {
+          if(!copyState.processedDocumentIds.find(p => p[0] === action.processedDocId)) {
+            copyState.processedDocumentIds.push([action.processedDocId, docId]);
+          }
+        }
+
         break;
       }
 
@@ -496,7 +504,7 @@ const formDataReducer: Reducer<
             if (deletedDocIds.length > 0) {
               // #region 継承後のデータ引継ぎ用に削除した子ドキュメントの情報を持っておく
               copyState.deletedDocuments = []; // 初期化
-              copyState.processedDocumentIds = new Set(); // 反映済みドキュメントID初期化
+              copyState.processedDocumentIds = []; // 反映済みドキュメントID初期化
               deletedDocIds.forEach((deleteDocId) => {
                 // 親ドキュメント
                 const pDoc = saveData.jesgo_document.find((p) =>
@@ -545,7 +553,9 @@ const formDataReducer: Reducer<
       // データ引継ぎ済みdocumentIdの更新
       case 'DATA_TRANSFER_PROCESSED': {
         if (action.processedDocId) {
-          copyState.processedDocumentIds.add(action.processedDocId);
+          if(!copyState.processedDocumentIds.find(p => p[0] === action.processedDocId)) {
+            copyState.processedDocumentIds.push([action.processedDocId, action.processedNewDocId]);
+          }
         }
         break;
       }


### PR DESCRIPTION
https://github.com/jesgo-toitu/jesgo-frontend/issues/176 [バグ]スキーマ継承時、元の子ドキュメントが別の親ドキュメントに復元されてしまうことがある

上記のバグを修正