### PR TITLE
jesgo:errorの表示対応

### DIFF
--- a/src/common/CaseRegistrationUtility.ts
+++ b/src/common/CaseRegistrationUtility.ts
@@ -23,6 +23,23 @@ import {
   validationResult,
 } from '../components/CaseRegistration/Definition';
 
+// formDataからjesgo:errorを取り出して削除
+export const popJesgoError = (formData: any) => {
+  let popValue: any[] = [];
+  if (formData && !Array.isArray(formData) && typeof formData === 'object') {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (formData['jesgo:error']) {
+      // 取り出して元のformDataからは削除
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      popValue = formData['jesgo:error'];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, no-param-reassign
+      delete formData['jesgo:error'];
+    }
+  }
+
+  return popValue;
+};
+
 /**
  * 入力値のvalidation
  * @param resultSchema

--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -7,8 +7,12 @@ import { JSONSchema7 } from 'webpack/node_modules/schema-utils/declarations/Vali
 import { JESGOFiledTemplete } from './JESGOFieldTemplete';
 import { JESGOComp } from './JESGOComponent';
 import store from '../../store';
-import { isNotEmptyObject } from '../../common/CaseRegistrationUtility';
-import { RegistrationErrors } from './Definition';
+import {
+  GetSchemaTitle,
+  isNotEmptyObject,
+  popJesgoError,
+} from '../../common/CaseRegistrationUtility';
+import { RegistrationErrors, VALIDATE_TYPE } from './Definition';
 import { CreateUISchema } from './UISchemaUtility';
 
 interface CustomDivFormProp extends FormProps<any> {
@@ -18,6 +22,7 @@ interface CustomDivFormProp extends FormProps<any> {
   setFormData: React.Dispatch<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   documentId: string;
   isTabItem: boolean;
+  setErrors: React.Dispatch<React.SetStateAction<RegistrationErrors[]>>;
 }
 
 // カスタムフォーム
@@ -27,7 +32,8 @@ interface CustomDivFormProp extends FormProps<any> {
 // - onChangeでuseStateで保持しているformDataを更新する
 const CustomDivForm = (props: CustomDivFormProp) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { schemaId, dispatch, setFormData, documentId, isTabItem } = props;
+  const { schemaId, dispatch, setFormData, documentId, isTabItem, setErrors } =
+    props;
   let { formData, schema } = props;
 
   const copyProps = { ...props };
@@ -39,12 +45,6 @@ const CustomDivForm = (props: CustomDivFormProp) => {
   if (thisDocument) {
     formData = thisDocument.value.document;
   }
-
-  // 継承直後、データ入力判定を動かすためにsetFormDataする
-  if (JSON.stringify(copyProps.formData) !== JSON.stringify(formData)) {
-    setFormData(formData);
-  }
-  copyProps.formData = formData;
 
   // validationエラーの取得
   const errors = store.getState().formDataReducer.extraErrors;
@@ -59,6 +59,52 @@ const CustomDivForm = (props: CustomDivFormProp) => {
       schema = targetErrors.validationResult.schema;
     }
   }
+
+  // プラグインにて付与されたjesgo:errorがformDataにあればエラーとして表示する
+  const jesgoErrors = popJesgoError(formData);
+  if (jesgoErrors.length > 0) {
+    let tmpErr = errors.find((p) => p.documentId === documentId);
+    if (!tmpErr) {
+      tmpErr = {
+        errDocTitle: GetSchemaTitle(schemaId),
+        schemaId,
+        documentId,
+        validationResult: { schema, messages: [] },
+      };
+      errors.push(tmpErr);
+    }
+
+    const messages = tmpErr.validationResult.messages;
+
+    jesgoErrors.forEach((errorItem) => {
+      if (typeof errorItem === 'string') {
+        // 文字列の場合はそのまま表示
+        messages.push({
+          message: `　　${errorItem}`,
+          validateType: VALIDATE_TYPE.Message,
+        });
+      } else if (typeof errorItem === 'object') {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        Object.entries(errorItem).forEach((item) => {
+          // objectの場合はKeyに項目名、valueにメッセージが格納されている想定
+          messages.push({
+            message: `　　[ ${item[0]} ] ${item[1] as string}`,
+            validateType: VALIDATE_TYPE.Message,
+          });
+        });
+      }
+    });
+
+    setErrors([...errors]);
+    dispatch({ type: 'SET_ERROR', extraErrors: errors });
+  }
+
+  // 継承直後、データ入力判定を動かすためにsetFormDataする
+  if (JSON.stringify(copyProps.formData) !== JSON.stringify(formData)) {
+    setFormData(formData);
+  }
+
+  copyProps.formData = formData;
 
   // uiSchema作成
   const uiSchema = CreateUISchema(schema);

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -571,6 +571,7 @@ const PanelSchema = React.memo((props: Props) => {
           schema={customSchema}
           formData={formData} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
           isTabItem={false}
+          setErrors={setErrors}
         />
         <ControlButton
           tabId={parentTabsId}

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -519,6 +519,7 @@ const RootSchema = React.memo((props: Props) => {
           formData={formData} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
           schema={customSchema}
           isTabItem
+          setErrors={setErrors}
         />
         <ControlButton
           tabId={tabId}

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -570,6 +570,7 @@ const TabSchema = React.memo((props: Props) => {
           schema={customSchema}
           formData={formData} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
           isTabItem
+          setErrors={setErrors}
         />
         <ControlButton
           tabId={tabId}


### PR DESCRIPTION
プラグインによりドキュメント内にjesgo:errorが追加されていた場合にエラーとして表示する対応
**プラグイン対応の基礎がマージされた後にマージ推奨**

[仕様]
- 症例登録表示時にjesgo:errorがドキュメントにあればエラーとして表示する
- formDataにあると通常の項目として表示されてしまうため、formDataからはjesgo:errorを除外する
- formDataから除外されるため、保存すると消える