### PR TITLE
eventdateがあるスキーマの入力値を変更して保存後、リストに戻ると編集中データ有アラートが表示される問題を修正

### DIFF
--- a/src/common/CaseRegistrationUtility.ts
+++ b/src/common/CaseRegistrationUtility.ts
@@ -873,7 +873,8 @@ const GET_CHANGE_TYPE = {
 const transferFormData = (
   formData: any,
   baseCustomSchema: JSONSchema7,
-  changedSchema: JSONSchema7
+  changedSchema: JSONSchema7,
+  isOnChange = false // formDataのonChangeかどうか
 ) => {
   // TODO: 必ずオブジェクトではないので切り分けが必要
   const newFormData: Obj = {};
@@ -893,7 +894,9 @@ const transferFormData = (
     }
 
     // 継承先にデフォルト値設定ありの場合は引き継がない
+    // formDataのonChange時はデフォルト値設定されないので引き継ぐ
     if (
+      !isOnChange &&
       jsonSchema2 &&
       jsonSchema2.default != null &&
       jsonSchema2.default !== ''
@@ -946,7 +949,8 @@ export const GetChangedFormData = (
   inheritSchemaId: number,
   oldSchemaInfo: JSONSchema7 | null,
   eventDate: string,
-  formData: any
+  formData: any,
+  isOnChange = false
 ) => {
   // 形式に関わらずformDataが存在しないか中身が空の場合はそのまま使いまわす
   if (
@@ -982,7 +986,7 @@ export const GetChangedFormData = (
     // 継承先のスキーマ
     changedSchema = CustomSchema({
       orgSchema: changedSchemaInfo.document_schema,
-      formData: {},
+      formData,
     });
   }
   // バージョン変更の場合
@@ -1000,24 +1004,30 @@ export const GetChangedFormData = (
     // 継承先のスキーマ
     changedSchema = CustomSchema({
       orgSchema: changedSchemaInfo.document_schema,
-      formData: {},
+      formData,
     });
   }
 
   // formDataが配列の場合は配列の中身を1つずつ処理
   if (Array.isArray(formData)) {
     return formData.map((fm) =>
-      transferFormData(fm, baseCustomSchema, changedSchema)
+      transferFormData(fm, baseCustomSchema, changedSchema, isOnChange)
     );
   }
 
-  return transferFormData(formData, baseCustomSchema, changedSchema);
+  return transferFormData(
+    formData,
+    baseCustomSchema,
+    changedSchema,
+    isOnChange
+  );
 };
 
 export const GetInheritFormData = (
   baseSchemaId: number,
   inheritSchemaId: number,
-  formData: any
+  formData: any,
+  isOnChange = false
 ) =>
   GetChangedFormData(
     GET_CHANGE_TYPE.INHERIT,
@@ -1025,14 +1035,16 @@ export const GetInheritFormData = (
     inheritSchemaId,
     null,
     '',
-    formData
+    formData,
+    isOnChange
   );
 
 export const GetVersionedFormData = (
   schemaId: number,
   oldSchemaInfo: JSONSchema7,
   eventDate: string,
-  formData: any
+  formData: any,
+  isOnChange = false
 ) =>
   GetChangedFormData(
     GET_CHANGE_TYPE.VERSION,
@@ -1040,7 +1052,8 @@ export const GetVersionedFormData = (
     schemaId,
     oldSchemaInfo,
     eventDate,
-    formData
+    formData,
+    isOnChange
   );
 
 export const GetBeforeInheritDocumentData = (

--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -183,7 +183,8 @@ const CustomDivForm = (props: CustomDivFormProp) => {
           GetSchemaIdFromString(e.schema.$id!),
           e.schema,
           currentEventDate,
-          data
+          data,
+          true
         );
         if (newFormdata) {
           if (


### PR DESCRIPTION
"jesgo:set": "eventdate" が定義されている項目があるスキーマにおいて保存したにも関わらずリストに戻るボタンを押した際に編集中のアラートが表示されてしまうケースがあったため修正  
今回のverupにより発生

### 問題1
eventdateの項目の入力値を変更するとスキーマ切り替え処理にて新しいformDataが生成されるが、デフォルト値がある項目は引き継がない対応を行ったことによりデフォルト値が内部的に消えていた。(デフォルト値の項目に赤枠が表示される)
formDataのonChange時はデフォルト値の自動設定はされないため、保存時の状態と異なったことによりアラートが表示されていた

#### 対応
onChange時はデフォルト値の引継ぎを行うよう修正

### 問題2
新しいformDataを生成する処理でif-then-elseで表示/非表示を切り替えている項目(子宮頸がんの予後調査など)が引き継がれないようになっていたため、保存時の状態と異なったことによりアラートが表示されていた

#### 対応
切り替え先のスキーマ取得時にベースとなるformDataが空になっていたので現在のformDataを使用するよう修正