### PR TITLE
タブ切り替え時の速度改善

### DIFF
--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import lodash from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Form, { FormProps, IChangeEvent } from '@rjsf/core';
 import { Dispatch } from 'redux';
 import { JSONSchema7 } from 'webpack/node_modules/schema-utils/declarations/ValidationError';
@@ -59,15 +59,21 @@ const CustomDivForm = (props: CustomDivFormProp) => {
     formData = thisDocument.value.document;
   }
 
+  const schemaData = store
+    .getState()
+    .schemaDataReducer.schemaDatas.get(schemaId);
   // 無限ループチェック
-  const loopCheck = checkEventDateInfinityLoop(
-    formData,
-    store.getState().schemaDataReducer.schemaDatas.get(schemaId)
+  const loopCheck = useMemo(
+    () => checkEventDateInfinityLoop(formData, schemaData),
+    [formData, schemaData]
   );
   // eventdateの初期値設定
   let initEventDate = '';
   if (thisDocument) {
-    initEventDate = getEventDate(thisDocument, formData);
+    initEventDate = useMemo(
+      () => getEventDate(thisDocument, formData),
+      [thisDocument, formData]
+    );
   }
 
   const [eventDate, setEventDate] = useState<string>(initEventDate);
@@ -107,7 +113,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
   }
 
   // uiSchema作成
-  const uiSchema = CreateUISchema(schema);
+  const uiSchema = useMemo(() => CreateUISchema(schema), [schema]);
   if (isTabItem) {
     uiSchema['ui:ObjectFieldTemplate'] =
       JESGOFiledTemplete.TabItemFieldTemplate;

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -70,10 +70,16 @@ const PanelSchema = React.memo((props: Props) => {
   const saveDoc = store
     .getState()
     .formDataReducer.saveData.jesgo_document.find((p) => p.key === documentId);
-  const eventDate = saveDoc ? getEventDate(saveDoc, formData) : null;
+  const eventDate = useMemo(
+    () => (saveDoc ? getEventDate(saveDoc, formData) : null),
+    [saveDoc, formData]
+  );
 
   // schemaIdをもとに情報を取得
-  const schemaInfo = GetSchemaInfo(schemaId, eventDate) as JesgoDocumentSchema;
+  const schemaInfo = useMemo(
+    () => GetSchemaInfo(schemaId, eventDate) as JesgoDocumentSchema,
+    [schemaId, eventDate]
+  );
   if (schemaInfo == null) {
     return null;
   }
@@ -112,7 +118,10 @@ const PanelSchema = React.memo((props: Props) => {
     subschema,
     child_schema: childSchema,
   } = schemaInfo;
-  const customSchema = CustomSchema({ orgSchema: documentSchema, formData }); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+  const customSchema = useMemo(
+    () => CustomSchema({ orgSchema: documentSchema, formData }),
+    [documentSchema, formData]
+  ); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
   const isTab = customSchema[Const.EX_VOCABULARY.UI_SUBSCHEMA_STYLE] === 'tab';
 
   // unique=falseの追加可能なサブスキーマまたは未作成サブスキーマ

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -93,10 +93,16 @@ const RootSchema = React.memo((props: Props) => {
   const saveDoc = store
     .getState()
     .formDataReducer.saveData.jesgo_document.find((p) => p.key === documentId);
-  const eventDate = saveDoc ? getEventDate(saveDoc, formData) : null;
+  const eventDate = useMemo(
+    () => (saveDoc ? getEventDate(saveDoc, formData) : null),
+    [saveDoc, formData]
+  );
 
   // ルートのschema情報を取得
-  const schemaInfo = GetSchemaInfo(schemaId, eventDate) as JesgoDocumentSchema;
+  const schemaInfo = useMemo(
+    () => GetSchemaInfo(schemaId, eventDate) as JesgoDocumentSchema,
+    [schemaId, eventDate]
+  );
   if (schemaInfo === undefined) {
     return null;
   }
@@ -105,7 +111,10 @@ const RootSchema = React.memo((props: Props) => {
     subschema,
     child_schema: childSchema,
   } = schemaInfo;
-  const customSchema = CustomSchema({ orgSchema: documentSchema, formData }); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+  const customSchema = useMemo(
+    () => CustomSchema({ orgSchema: documentSchema, formData }),
+    [documentSchema, formData]
+  ); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
 
   // unique=falseの追加可能なサブスキーマまたは未作成サブスキーマ
   const addableSubSchemaIds = useMemo(() => {

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -18,7 +18,6 @@ import { JesgoDocumentSchema } from '../../store/schemaDataReducer';
 import {
   dispSchemaIdAndDocumentIdDefine,
   jesgoDocumentObjDefine,
-  SaveDataObjDefine,
 } from '../../store/formDataReducer';
 import { CustomSchema, GetSchemaInfo } from './SchemaUtility';
 import { createPanels, createTabs } from './FormCommonComponents';
@@ -99,10 +98,16 @@ const TabSchema = React.memo((props: Props) => {
   const saveDoc = store
     .getState()
     .formDataReducer.saveData.jesgo_document.find((p) => p.key === documentId);
-  const eventDate = saveDoc ? getEventDate(saveDoc, formData) : null;
+  const eventDate = useMemo(
+    () => (saveDoc ? getEventDate(saveDoc, formData) : null),
+    [saveDoc, formData]
+  );
 
   // schemaIdをもとに情報を取得
-  const schemaInfo = GetSchemaInfo(schemaId, eventDate) as JesgoDocumentSchema;
+  const schemaInfo = useMemo(
+    () => GetSchemaInfo(schemaId, eventDate) as JesgoDocumentSchema,
+    [schemaId, eventDate]
+  );
   const {
     document_schema: documentSchema,
     subschema,
@@ -133,7 +138,10 @@ const TabSchema = React.memo((props: Props) => {
 
   const dispatch = useDispatch();
 
-  const customSchema = CustomSchema({ orgSchema: documentSchema, formData }); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+  const customSchema = useMemo(
+    () => CustomSchema({ orgSchema: documentSchema, formData }),
+    [documentSchema, formData]
+  ); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
   const isTab = customSchema[Const.EX_VOCABULARY.UI_SUBSCHEMA_STYLE] === 'tab';
 
   const [childTabSelectedFunc, setChildTabSelectedFunc] =

--- a/src/store/commonReducer.ts
+++ b/src/store/commonReducer.ts
@@ -33,7 +33,7 @@ const commonReducer: Reducer<commonState, commonAction> = (
   state = initialState,
   action: commonAction // eslint-disable-line @typescript-eslint/no-explicit-any
 ) => {
-  const copyState = lodash.cloneDeep(state); // 現在の状態をコピー
+  const copyState = state;
 
   switch (action.type) {
     // スクロール位置保存

--- a/src/store/formDataReducer.ts
+++ b/src/store/formDataReducer.ts
@@ -298,7 +298,7 @@ const formDataReducer: Reducer<
     return initialState;
   }
 
-  const copyState = lodash.cloneDeep(state); // 現在の状態をコピー
+  const copyState = state;
 
   const { formDatas, saveData } = copyState;
 

--- a/src/store/schemaDataReducer.ts
+++ b/src/store/schemaDataReducer.ts
@@ -53,7 +53,7 @@ const schemaDataReducer: Reducer<schemaDataState, schemaDataAction> = (
   state = initialState,
   action: schemaDataAction
 ) => {
-  const copyState = lodash.cloneDeep(state); // 現在の状態をコピー
+  const copyState = state;
   switch (action.type) {
     case 'SCHEMA':
       // 一旦配列をクリアする
@@ -117,7 +117,7 @@ const schemaDataReducer: Reducer<schemaDataState, schemaDataAction> = (
       copyState.blackList = action.blackList;
 
       break;
-      
+
     default:
   }
   return copyState;


### PR DESCRIPTION
症例登録でルートドキュメントが8つ程度作成済みの場合、タブ選択でドキュメントを切り替えるのに1秒ほどかかっていたので速度改善を実施

- 変更前：1000ms前後
- 変更後：  250ms前後

### 修正内容
- commonReducer、formDataReducer、schemaDataReducer使用時に通る現在値のコピー(lodash.cloneDeep)を廃止
　→特に現在値を使用している処理がなかったため不要
- コンポーネント内のスキーマ情報取得処理などをuseMemoを用いてキャッシュ化した