### PR TITLE
コンボボックスのアイコン表示対応

### DIFF
--- a/src/components/CaseRegistration/JESGOComponent.tsx
+++ b/src/components/CaseRegistration/JESGOComponent.tsx
@@ -636,6 +636,7 @@ export namespace JESGOComp {
           disableListWrap
           disableClearable
           freeSolo
+          forcePopupIcon={comboItemList.length > 0}
           clearOnBlur={false}
           handleHomeEndKeys={false}
           disabled={readonly}

--- a/src/components/CaseRegistration/JESGOComponent.tsx
+++ b/src/components/CaseRegistration/JESGOComponent.tsx
@@ -552,7 +552,7 @@ export namespace JESGOComp {
         document.body.appendChild(div); // bodyに追加して描画
 
         // divの幅を取得。マージンなどを考慮して補正かける
-        const tmpWidth = div.clientWidth + 60;
+        const tmpWidth = div.clientWidth + 100;
         if (tmpWidth > comboWidth) {
           comboWidth = tmpWidth;
         }


### PR DESCRIPTION
#191 の課題の対応
suggest_listにした際のコンボボックスで矢印アイコンを表示させるよう対応

※material-uiのAutoCompleteにはforcePopupIconというプロパティがあり、Trueにすると矢印アイコンが強制的に表示できることが判明