### PR TITLE
ユーザ権限による機能制限対応

### DIFF
--- a/src/components/CaseRegistration/FormCommonComponents.tsx
+++ b/src/components/CaseRegistration/FormCommonComponents.tsx
@@ -189,8 +189,8 @@ export const createTabs = (
     // インデックスからタブ名に変換
     const convTabKey = convertTabKey(id, eventKey);
 
-    // 変更ない場合は保存しないでタブ移動
-    if (IsNotUpdate()) {
+    // 変更ない場合は保存しないでタブ移動。編集権限ない場合も同様
+    if (IsNotUpdate() || localStorage.getItem('is_edit_roll') !== 'true') {
       setSelectedTabKey(convTabKey);
       return;
     }

--- a/src/components/CaseRegistration/SubmitButton.tsx
+++ b/src/components/CaseRegistration/SubmitButton.tsx
@@ -146,6 +146,7 @@ const SubmitButton = (props: ButtonProps) => {
   // 保存せずリストに戻る
   const clickCancel = () => {
     if (
+      localStorage.getItem('is_edit_roll') !== 'true' ||
       IsNotUpdate() ||
       confirm(
         '画面を閉じて患者リストに戻ります。保存してないデータは失われます。\nよろしいですか？'
@@ -203,24 +204,28 @@ const SubmitButton = (props: ButtonProps) => {
           </Button>
         )}
         {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
-        <Button
-          bsStyle="success"
-          className="normal-button"
-          onClick={() => {
-            clickSubmit(false);
-          }}
-        >
-          保存
-        </Button>
-        <Button
-          onClick={() => {
-            clickSubmit(true);
-          }}
-          bsStyle="success"
-          className="normal-button"
-        >
-          保存してリストに戻る
-        </Button>
+        {localStorage.getItem('is_edit_roll') === 'true' && (
+          <>
+            <Button
+              bsStyle="success"
+              className="normal-button"
+              onClick={() => {
+                clickSubmit(false);
+              }}
+            >
+              保存
+            </Button>
+            <Button
+              onClick={() => {
+                clickSubmit(true);
+              }}
+              bsStyle="success"
+              className="normal-button"
+            >
+              保存してリストに戻る
+            </Button>
+          </>
+        )}
         <Button
           onClick={clickCancel}
           bsStyle="primary"

--- a/src/components/Patients/UserTables.tsx
+++ b/src/components/Patients/UserTables.tsx
@@ -135,11 +135,21 @@ const makeTable = (props: {
           <th className={search}>3年予後</th>
           <th className={search}>5年予後</th>
           <th className={noSearch}>ステータス</th>
-          {(localStorage.getItem('is_edit_roll') === 'true' ||
+          {(localStorage.getItem('is_view_roll') === 'true' ||
+            localStorage.getItem('is_edit_roll') === 'true' ||
             localStorage.getItem('is_remove_roll') === 'true') && (
             <th>
-              {localStorage.getItem('is_edit_roll') === 'true' && '編集'}
-              {localStorage.getItem('is_edit_roll') === 'true' &&
+              {
+                // eslint-disable-next-line no-nested-ternary
+                localStorage.getItem('is_view_roll') === 'true' &&
+                localStorage.getItem('is_edit_roll') === 'true'
+                  ? '編集'
+                  : localStorage.getItem('is_view_roll') === 'true'
+                  ? '閲覧'
+                  : null
+              }
+              {(localStorage.getItem('is_edit_roll') === 'true' ||
+                localStorage.getItem('is_view_roll') === 'true') &&
                 localStorage.getItem('is_remove_roll') === 'true' &&
                 '/'}
               {localStorage.getItem('is_remove_roll') === 'true' && '削除'}
@@ -191,11 +201,13 @@ const makeTable = (props: {
               <IconList iconList={user.status} />
             </td>
             {(localStorage.getItem('is_edit_roll') === 'true' ||
+              localStorage.getItem('is_view_roll') === 'true' ||
               localStorage.getItem('is_remove_roll') === 'true') && (
               <td>
                 <ButtonToolbar>
                   <ButtonGroup>
-                    {localStorage.getItem('is_edit_roll') === 'true' && (
+                    {(localStorage.getItem('is_edit_roll') === 'true' ||
+                      localStorage.getItem('is_view_roll') === 'true') && (
                       <Button onClick={() => clickEdit(user.caseId)}>
                         <Glyphicon glyph="edit" />
                       </Button>

--- a/src/components/common/SystemMenu.tsx
+++ b/src/components/common/SystemMenu.tsx
@@ -50,9 +50,8 @@ export const SystemMenu = (props: {
   }, []);
 
   const handlPluginManager = useCallback(() => {
-    // TODO: プラグイン管理画面を開ける権限はまた別途あるので修正必要あり
     if (isConfirm === null || isConfirm()) {
-      const auth = localStorage.getItem('is_system_manage_roll');
+      const auth = localStorage.getItem('is_plugin_registerable');
       if (auth === 'true') {
         RemoveBeforeUnloadEvent();
         navigate('/PluginManager');

--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -118,7 +118,7 @@ export const Login = () => {
     } else {
       // eslint-disable-next-line no-alert
       alert(
-        `【エラー】\nログインに失敗しました。ユーザ名かパスワードが間違っています。`
+        `【エラー】\nログインに失敗しました。ユーザ名かパスワードが間違っています。\nまたはログイン権限がありません。`
       );
       setIsLoading(false);
     }

--- a/src/views/Registration.tsx
+++ b/src/views/Registration.tsx
@@ -369,8 +369,8 @@ const Registration = () => {
     // インデックスからタブ名に変換
     const convTabKey = convertTabKey('root-tab', eventKey);
 
-    // 変更ない場合はそのままタブ移動
-    if (IsNotUpdate()) {
+    // 変更ない場合はそのままタブ移動。編集権限ない場合も同様
+    if (IsNotUpdate() || localStorage.getItem('is_edit_roll') !== 'true') {
       setSelectedTabKey(convTabKey);
       return;
     }


### PR DESCRIPTION
#182 
上記課題の対応。**バックエンド側も修正あり**

### フロント側変更点
- ログイン失敗時のメッセージにログイン権限がない旨を追加
	- APIからは通常のエラーが返ってくるため元のメッセージに追記
- プラグイン管理画面オープン権限をplugin_registableへ変更
- 患者一覧から症例登録画面へ遷移するための編集ボタンを権限により制御追加
	- 編集ボタン：view権限、またはedit権限がある場合に表示。view権限のみの場合はヘッダを「閲覧」に変更
	- 削除ボタン：remove権限がある場合に表示
- 症例登録画面
	- edit権限がない場合、保存ボタン、保存してリストに戻るボタンを非表示にした。これによりview権限しかないユーザは閲覧はできるが保存できない状態になる
	- edit権限がない場合、タブ移動時の保存も無効化