### PR TITLE
症例登録画面上のjesgo:errorの表示が重複してしまうケースの修正

### DIFF
--- a/src/common/DBUtility.ts
+++ b/src/common/DBUtility.ts
@@ -557,6 +557,7 @@ export const hasJesgoCaseError = (
       schemaError.validationResult.messages.filter(
         (p) =>
           p.validateType !== VALIDATE_TYPE.Message &&
+          p.validateType !== VALIDATE_TYPE.JesgoError &&
           p.validateType !== VALIDATE_TYPE.Required
       ).length > 0
     ) {
@@ -693,13 +694,13 @@ export const UploadPluginFile = async (
   res.resCode = apiResult.statusNum;
   if (apiBody && apiBody.number > 0) {
     res.message = `${apiBody.number}件のプラグインを更新しました`;
-    if(apiBody.message.length > 0) {
-      res.message += `\n${apiBody.message.join('\n')}`
+    if (apiBody.message.length > 0) {
+      res.message += `\n${apiBody.message.join('\n')}`;
     }
   } else {
     res.message = '【エラー】\nプラグインの更新に失敗しました';
-    if(apiBody.message.length > 0) {
-      res.message += `\n${apiBody.message.join('\n')}`
+    if (apiBody.message.length > 0) {
+      res.message += `\n${apiBody.message.join('\n')}`;
     }
   }
 

--- a/src/components/CaseRegistration/Definition.ts
+++ b/src/components/CaseRegistration/Definition.ts
@@ -25,6 +25,7 @@ export enum VALIDATE_TYPE {
   Number, // 非数値エラー
   Integer, // 非整数エラー
   Other, // その他エラー
+  JesgoError, // jesgo:error
 }
 
 export type ValidationItem = {

--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -101,7 +101,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
   }
 
   // validationエラーの取得
-  const errors = store.getState().formDataReducer.extraErrors;
+  let errors = store.getState().formDataReducer.extraErrors;
   if (errors) {
     const targetErrors = errors.find(
       (x: RegistrationErrors) => x.documentId === documentId
@@ -117,6 +117,13 @@ const CustomDivForm = (props: CustomDivFormProp) => {
   // プラグインにて付与されたjesgo:errorがformDataにあればエラーとして表示する
   const jesgoErrors = popJesgoError(formData);
   if (jesgoErrors.length > 0) {
+    // 元々あったjesgo:errorのエラーはクリアする
+    errors = errors.filter((p) =>
+      p.validationResult.messages.some(
+        (q) => q.validateType !== VALIDATE_TYPE.JesgoError
+      )
+    );
+
     let tmpErr = errors.find((p) => p.documentId === documentId);
     if (!tmpErr) {
       tmpErr = {
@@ -136,7 +143,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
         messages.push({
           // eslint-disable-next-line no-irregular-whitespace
           message: `　　${errorItem}`,
-          validateType: VALIDATE_TYPE.Message,
+          validateType: VALIDATE_TYPE.JesgoError,
         });
       } else if (typeof errorItem === 'object') {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -145,7 +152,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
           messages.push({
             // eslint-disable-next-line no-irregular-whitespace
             message: `　　[ ${item[0]} ] ${item[1] as string}`,
-            validateType: VALIDATE_TYPE.Message,
+            validateType: VALIDATE_TYPE.JesgoError,
           });
         });
       }


### PR DESCRIPTION
以下の手順でjesgo:errorの内容が重複して表示される問題を修正
1. 症例登録画面からjesgo:error更新用のプラグインを実行
※このプラグインではjesgo:error配列の末尾に追記する形ではなく、置き換えを指定する
2. 再度プラグインを実行すると上書き確認ダイアログが表示されるのでキャンセルする
→　画面上に同じ内容のjesgo:errorが2つ表示される。DB上は重複していない

### 原因
画面再描画時、再描画前のエラーに追記する形にしているため同じエラー内容が追加されていた

### 対応
error追加前にjesgo:error関連のエラーを一旦削除後、再度ドキュメントのjesgo:errorを追加する