### PR TITLE
jesgo:error表示時、uiSchemaのエラーが発生する問題を修正

### DIFF
--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -126,6 +126,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
 
     let tmpErr = errors.find((p) => p.documentId === documentId);
     if (!tmpErr) {
+      schema = CustomSchema({ orgSchema: schema, formData });
       tmpErr = {
         errDocTitle: GetSchemaTitle(schemaId),
         schemaId,

--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -126,7 +126,6 @@ const CustomDivForm = (props: CustomDivFormProp) => {
 
     let tmpErr = errors.find((p) => p.documentId === documentId);
     if (!tmpErr) {
-      schema = CustomSchema({ orgSchema: schema, formData });
       tmpErr = {
         errDocTitle: GetSchemaTitle(schemaId),
         schemaId,
@@ -171,7 +170,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
   copyProps.formData = formData;
 
   // uiSchema作成
-  const uiSchema = useMemo(() => CreateUISchema(schema), [schema]);
+  const uiSchema = CreateUISchema(schema);
   if (isTabItem) {
     uiSchema['ui:ObjectFieldTemplate'] =
       JESGOFiledTemplete.TabItemFieldTemplate;


### PR DESCRIPTION
### 不具合
表示内容をformDataの内容からif-then-elseで切り替えているスキーマのドキュメントにjesgo:errorを追加すると
uiSchemaのOrderList関連のエラーが発生し、UIが表示されない

### 原因
~~jesgo:error表示時にスキーマ情報を渡していたが、formDataの内容によるスキーマ書き換え前に渡していたため
実際に表示される項目とuiSchemaの項目に齟齬が出たためエラーとなっていた~~
→速度改善の際にuseMemoを用いuiSchemaをキャッシュ化したが、その影響でスキーマ情報が古いままになっていた

### 対応
uiSchemaにuseMemo使用しない