### PR TITLE
症例登録でのプラグインを用いたデータ更新後、エラー表示が更新されない件を修正

### DIFF
--- a/src/components/CaseRegistration/SubmitButton.tsx
+++ b/src/components/CaseRegistration/SubmitButton.tsx
@@ -13,23 +13,19 @@ import { IsNotUpdate } from '../../common/CaseRegistrationUtility';
 import { RegistrationErrors } from './Definition';
 import { jesgoPluginColumns } from '../../common/Plugin';
 import { TargetPatientPluginButton } from '../common/PluginButton';
+import { reloadState } from '../../views/Registration';
 
 interface ButtonProps {
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setLoadedJesgoCase: React.Dispatch<React.SetStateAction<responseResult>>;
   setCaseId: React.Dispatch<React.SetStateAction<number | undefined>>;
-  setIsReload: React.Dispatch<React.SetStateAction<boolean>>;
+  setReload: React.Dispatch<React.SetStateAction<reloadState>>;
   setErrors: React.Dispatch<React.SetStateAction<RegistrationErrors[]>>;
 }
 
 const SubmitButton = (props: ButtonProps) => {
-  const {
-    setIsLoading,
-    setLoadedJesgoCase,
-    setCaseId,
-    setIsReload,
-    setErrors,
-  } = props;
+  const { setIsLoading, setLoadedJesgoCase, setCaseId, setReload, setErrors } =
+    props;
 
   const [jesgoPluginList, setJesgoPluginList] = useState<jesgoPluginColumns[]>(
     []
@@ -92,7 +88,7 @@ const SubmitButton = (props: ButtonProps) => {
           loadedSaveData: undefined,
         });
         setCaseId(saveResponse.caseId);
-        setIsReload(true);
+        setReload({ isReload: true, caller: '' });
       } else {
         // 読み込み失敗
         setIsLoading(false);
@@ -158,7 +154,7 @@ const SubmitButton = (props: ButtonProps) => {
           pluginList={jesgoPluginList}
           getTargetFunction={getPatient}
           setIsLoading={setIsLoading}
-          setReload={setIsReload}
+          setReload={setReload}
         />
         {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
         {localStorage.getItem('is_edit_roll') === 'true' && (

--- a/src/components/common/PluginButton.tsx
+++ b/src/components/common/PluginButton.tsx
@@ -10,6 +10,7 @@ import { fTimeout } from '../../common/CommonUtility';
 import { Const } from '../../common/Const';
 import { executePlugin, jesgoPluginColumns } from '../../common/Plugin';
 import { jesgoCaseDefine } from '../../store/formDataReducer';
+import { reloadState } from '../../views/Registration';
 
 const PAGE_TYPE = {
   PATIENT_LIST: 0,
@@ -21,7 +22,9 @@ const PluginButton = (props: {
   pluginList: jesgoPluginColumns[];
   getTargetFunction: () => jesgoCaseDefine[];
   setIsLoading: (value: React.SetStateAction<boolean>) => void;
-  setReload: (value: React.SetStateAction<boolean>) => void;
+  setReload: (
+    value: React.SetStateAction<reloadState>
+  ) => void;
 }) => {
   const { pageType, pluginList, getTargetFunction, setIsLoading, setReload } =
     props;
@@ -67,7 +70,13 @@ const PluginButton = (props: {
       setIsLoading(true);
       await Promise.race([
         fTimeout(Const.PLUGIN_TIMEOUT_SEC),
-        executePlugin(plugin, getTargetFunction(), undefined, setReload, setIsLoading),
+        executePlugin(
+          plugin,
+          getTargetFunction(),
+          undefined,
+          setReload,
+          setIsLoading
+        ),
       ])
         .then((res) => {
           if (!plugin.update_db) {
@@ -109,7 +118,9 @@ export const PatientListPluginButton = (props: {
   pluginList: jesgoPluginColumns[];
   getTargetFunction: () => jesgoCaseDefine[];
   setIsLoading: (value: React.SetStateAction<boolean>) => void;
-  setReload: (value: React.SetStateAction<boolean>) => void;
+  setReload: (
+    value: React.SetStateAction<reloadState>
+  ) => void;
 }) => {
   const { pluginList, getTargetFunction, setIsLoading, setReload } = props;
   return PluginButton({
@@ -125,7 +136,9 @@ export const TargetPatientPluginButton = (props: {
   pluginList: jesgoPluginColumns[];
   getTargetFunction: () => jesgoCaseDefine[];
   setIsLoading: (value: React.SetStateAction<boolean>) => void;
-  setReload: (value: React.SetStateAction<boolean>) => void;
+  setReload: (
+    value: React.SetStateAction<reloadState>
+  ) => void;
 }) => {
   const { pluginList, getTargetFunction, setIsLoading, setReload } = props;
   return PluginButton({

--- a/src/views/Patients.tsx
+++ b/src/views/Patients.tsx
@@ -37,6 +37,7 @@ import SearchDateComponent, {
   convertSearchDate,
   searchDateInfoDataSet,
 } from '../components/common/SearchDateComponent';
+import { reloadState } from './Registration';
 
 const UNIT_TYPE = {
   DAY: 0,
@@ -131,7 +132,10 @@ const Patients = () => {
     []
   );
   const [isLoading, setIsLoading] = useState(false);
-  const [isReload, setIsReload] = useState(false);
+  const [reload, setReload] = useState<reloadState>({
+    isReload: false,
+    caller: '',
+  });
 
   // 初回治療開始日検索条件
   const [searchDateInfoInitialTreatment, setSearchDateInfoInitialTreatment] =
@@ -173,12 +177,12 @@ const Patients = () => {
       setIsLoading(false);
     };
 
-    if (isReload) {
+    if (reload.isReload) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       f();
-      setIsReload(false);
+      setReload({ isReload: false, caller: '' });
     }
-  }, [isReload]);
+  }, [reload]);
 
   useEffect(() => {
     const f = async () => {
@@ -686,7 +690,7 @@ const Patients = () => {
               pluginList={jesgoPluginList}
               getTargetFunction={getPatientList}
               setIsLoading={setIsLoading}
-              setReload={setIsReload}
+              setReload={setReload}
             />
             <div className="spacer10" />
             {localStorage.getItem('is_add_roll') === 'true' && (

--- a/src/views/Registration.tsx
+++ b/src/views/Registration.tsx
@@ -40,6 +40,7 @@ import {
   jesgoDocumentObjDefine,
 } from '../store/formDataReducer';
 import SaveCommand, {
+  hasJesgoCaseError,
   loadJesgoCaseAndDocument,
   responseResult,
 } from '../common/DBUtility';
@@ -61,6 +62,11 @@ import {
   ShowSaveDialogState,
   RegistrationErrors,
 } from '../components/CaseRegistration/Definition';
+
+export type reloadState = {
+  isReload: boolean;
+  caller: string;
+};
 
 // 症例入力のおおもとの画面
 const Registration = () => {
@@ -84,7 +90,10 @@ const Registration = () => {
   // 症例ID
   const [caseId, setCaseId] = useState<number>();
   // リロードフラグ
-  const [isReload, setIsReload] = useState<boolean>(false);
+  const [reload, setReload] = useState<reloadState>({
+    isReload: false,
+    caller: '',
+  });
 
   // 読み込み中フラグ
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -232,7 +241,10 @@ const Registration = () => {
       paramCaseId = query.get('id') ?? '';
     }
 
-    if (paramCaseId && (loadedJesgoCase.resCode === undefined || isReload)) {
+    if (
+      paramCaseId &&
+      (loadedJesgoCase.resCode === undefined || reload.isReload)
+    ) {
       // DBからデータ読み込み
       loadJesgoCaseAndDocument(parseInt(paramCaseId, 10), setLoadedJesgoCase);
     } else {
@@ -251,11 +263,11 @@ const Registration = () => {
   }, []);
 
   useEffect(() => {
-    if (isReload) {
+    if (reload.isReload) {
       setIsLoading(true);
       LoadDataFromDB();
     }
-  }, [isReload]);
+  }, [reload]);
 
   // データ読み込み後のコールバック
   useEffect(() => {
@@ -321,7 +333,12 @@ const Registration = () => {
         }
       }
 
-      setIsReload(false);
+      if (reload.isReload && reload.caller === 'update_plugin') {
+        // プラグインのデータ更新後のリロード時はエラー再設定
+        hasJesgoCaseError(loadData, setErrors, dispatch);
+      }
+
+      setReload({ isReload: false, caller: '' });
 
       // 患者情報しか入力されてない場合はローディング画面解除されないのでここで解除する
       if (jesgoDocument.length === 0) {
@@ -538,7 +555,7 @@ const Registration = () => {
           loadedSaveData: undefined,
         });
         setCaseId(saveResponse.caseId);
-        setIsReload(true);
+        setReload({ isReload: true, caller: '' });
       } else {
         // 読み込み失敗
         setIsLoading(false);
@@ -677,7 +694,7 @@ const Registration = () => {
             setIsLoading={setIsLoading}
             setLoadedJesgoCase={setLoadedJesgoCase}
             setCaseId={setCaseId}
-            setIsReload={setIsReload}
+            setReload={setReload}
             setErrors={setErrors}
           />
         </Panel>


### PR DESCRIPTION
症例登録画面からのデータ更新系プラグイン実行後、エラーチェックが行われていないため
未入力エラーが出ていた項目に対しプラグインで更新してもエラーが解消されていないように見えてしまう

プラグインでの更新は実際にDBへ書き込まれているので、保存ボタンを押した時と同様にエラーチェックも行う方が望ましい

### 対応
- プラグイン更新後のリロード時はエラーチェックも行うよう修正