### PR TITLE
#215 jesgo:ui:visibleWhenが複数あるとすべてのvisibleWhen項目が非表示になってしまう

### DIFF
--- a/src/common/Const.ts
+++ b/src/common/Const.ts
@@ -24,7 +24,7 @@ export namespace Const {
     UI_TEXTAREA: 'jesgo:ui:textarea',
     UI_LISTTYPE: 'jesgo:ui:listtype',
     UI_SUBSCHEMA_STYLE: 'jesgo:ui:subschemastyle',
-    UI_VISIBLE_WHWN: 'jesgo:ui:visibleWhen',
+    UI_VISIBLE_WHEN: 'jesgo:ui:visibleWhen',
     UI_HIDDEN: 'jesgo:ui:hidden',
   } as const;
 

--- a/src/components/CaseRegistration/UISchemaUtility.tsx
+++ b/src/components/CaseRegistration/UISchemaUtility.tsx
@@ -72,7 +72,7 @@ const AddUiSchema = (
   }
 
   // "jesgo:ui:visiblewhen"
-  if (schema[Const.EX_VOCABULARY.UI_VISIBLE_WHWN]) {
+  if (schema[Const.EX_VOCABULARY.UI_VISIBLE_WHEN]) {
     classNames.push('visiblewhen');
   }
 

--- a/src/views/Registration.css
+++ b/src/views/Registration.css
@@ -201,7 +201,7 @@ a.has-input {
 /* jesgo:ui:visibleWhen
 ※条件に当てはまらない場合このスタイルが付与される
 */
-.visiblewhen-hidden .visiblewhen {
+.visiblewhen-hidden .visiblewhen, .visiblewhen-item {
   display: none;
 }
 


### PR DESCRIPTION
#215 の対応
visibleWhenの判定を行う際オブジェクト内の項目のIDを取得し、docoment.getElementByIdでエレメントを取得して1つ1つ非表示用のCSSを登録・解除できるよう対応