### PR TITLE
[バグ]速度改善による不具合を修正

### DIFF
--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -72,10 +72,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
   // eventdateの初期値設定
   let initEventDate = '';
   if (thisDocument) {
-    initEventDate = useMemo(
-      () => getEventDate(thisDocument, formData),
-      [thisDocument, formData]
-    );
+    initEventDate = getEventDate(thisDocument, formData);
   }
 
   const [eventDate, setEventDate] = useState<string>(initEventDate);

--- a/src/store/commonReducer.ts
+++ b/src/store/commonReducer.ts
@@ -21,12 +21,14 @@ export interface commonAction {
   isShownSaveMessage?: boolean;
 }
 
-const initialState: commonState = {
+const createInitialState = (): commonState => ({
   scrollTop: 0,
   isHiddenSaveMassage: false,
   isSaveAfterTabbing: false,
   isShownSaveMessage: false,
-};
+});
+
+const initialState: commonState = createInitialState();
 
 const commonReducer: Reducer<commonState, commonAction> = (
   // eslint-disable-next-line default-param-last
@@ -62,7 +64,7 @@ const commonReducer: Reducer<commonState, commonAction> = (
 
     // 初期化
     case 'INIT_STORE': {
-      return initialState;
+      return createInitialState();
     }
     default:
       break;

--- a/src/store/formDataReducer.ts
+++ b/src/store/formDataReducer.ts
@@ -151,7 +151,7 @@ export interface headerInfoAction {
   value: string | boolean;
 }
 
-const initialState: formDataState = {
+const createInitialState = (): formDataState => ({
   formDatas: new Map(),
   saveData: {
     jesgo_case: {
@@ -195,7 +195,9 @@ const initialState: formDataState = {
   deletedDocuments: [],
   processedDocumentIds: [],
   formDataInputStates: new Map(),
-};
+});
+
+const initialState: formDataState = createInitialState();
 
 // 保存用オブジェクト作成(1スキーマ1オブジェクト)
 const createJesgoDocumentValueItem = (
@@ -302,7 +304,7 @@ const formDataReducer: Reducer<
 ) => {
   // 初期化の場合は常に初期値返す
   if (action.type === 'INIT_STORE') {
-    return initialState;
+    return createInitialState();
   }
 
   const copyState = state;


### PR DESCRIPTION
### 不具合内容
以下2つ
1. 症例登録でタブを追加後、保存確認ダイアログで「いいえ」を選択して保存せずに、追加したタブを削除すると画面が真っ白になる
2. 症例登録の保存確認ダイアログで「次回以降表示しない」にチェックを付けた後、患者一覧に戻ってから症例登録を再び開き、何か変更後タブを移動しても確認ダイアログが表示されない

### 原因
1. 速度改善でuseMemoを使うようにしたが、それの影響でエラーが発生していた
2. 速度改善でstoreのstateをコピーしないようにしたが、それの影響で初期化時に返しているinitialStateとstateが同じインスタンスになってしまい、初期化が行われていなかった

### 対応
- 一部useMemoを使用していた箇所を廃止
- storeの初期化時は新しいインスタンスを返すようにする