### PR TITLE
データ出力プラグイン実行時、OutputViewerにコードが表示されることがある問題を修正

### DIFF
--- a/src/common/CaseRegistrationUtility.ts
+++ b/src/common/CaseRegistrationUtility.ts
@@ -1160,17 +1160,16 @@ export const OpenOutputView = (
 };
 
 export const OpenOutputViewScript = (win: typeof window, srcData: string) => {
-  win.addEventListener(
-    'message',
-    (e) => {
-      // 画面の準備ができたらデータをポストする
-      if (e.origin === win.location.origin && e.data === 'output_ready') {
-        // ★TODO: 仮実装
-        e.source?.postMessage(srcData);
-      }
-    },
-    false
-  );
+  const postFunc = (e: MessageEvent) => {
+    // 画面の準備ができたらデータをポストする
+    if (e.origin === win.location.origin && e.data === 'output_ready') {
+      e.source?.postMessage(srcData);
+    }
+
+    win.removeEventListener('message', postFunc);
+  };
+
+  win.addEventListener('message', postFunc, false);
 
   win.open('/OutputView', 'outputview');
 };


### PR DESCRIPTION
### 不具合内容
以下手順を実施
1. プラグイン管理画面にて、適当なプラグインの内容(コード)を表示する
2. OutputViewerを閉じ、患者一覧などでデータ出力系プラグインを実行する
→　**OutputViewerが開かれるが、1で表示したコードが表示されることがある**

### 原因
OutputViewerを開く際にmessageイベントを登録してデータをOutputViewerへポストしているが
処理完了後のイベント解除が漏れていたため再度OutputViewerを開いた際に前回のデータがポストされてしまっていた。

### 対応
処理完了後、messageイベントを解除する