### PR TITLE
スキーマ指定ありのデータ出力時のAPI戻値をJSONに変更

### DIFF
--- a/src/common/Plugin.ts
+++ b/src/common/Plugin.ts
@@ -116,7 +116,7 @@ const getTargetDocument = async (doc: argDoc) => {
     pluginData.attach_patient_info
   );
   if (ret.resCode === RESULT.NORMAL_TERMINATION) {
-    return ret;
+    return ret.anyValue ? JSON.stringify(ret.anyValue) : undefined;
   }
   return undefined;
 };


### PR DESCRIPTION
### 概要
プラグイン実行時にmainの第2引数に渡すAPI実行用関数の戻値がオブジェクトになっていた箇所があったため修正

### 修正箇所
データ出力プラグインでmainの第2引数に渡している関数(getTargetDocument)の戻値をJSONへ修正
※プラグインのinitの値は以下を設定。この設定だと指定したスキーマのドキュメントのメニューにプラグイン実行が追加される
- all_patient: false
- update_db: false
- show_upload_dialog: false
- target_schyema_id_string: 指定あり


患者一覧から実行するデータ出力プラグインではgetPatientsDocumentという関数が実行されるが、こちらは元々JSONになっていたため修正なし
※念のためこちらも確認お願いします。> @kosaka-hokuto