### PR TITLE
ドキュメント単位のコントロールボタンから更新用プラグインを表示するように修正

### DIFF
--- a/src/components/CaseRegistration/FormCommonComponents.tsx
+++ b/src/components/CaseRegistration/FormCommonComponents.tsx
@@ -13,6 +13,8 @@ import {
   dispSchemaIdAndDocumentIdDefine,
   SaveDataObjDefine,
 } from '../../store/formDataReducer';
+import { reloadState } from '../../views/Registration';
+import { OverwriteDialogPlop } from '../common/PluginOverwriteConfirm';
 import {
   RegistrationErrors,
   ShowSaveDialogState,
@@ -37,7 +39,11 @@ export const createTab = (
   setErrors: React.Dispatch<React.SetStateAction<RegistrationErrors[]>>,
   selectedTabKey: any,
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void,
-  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>
+  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>,
+  setReload: (value: React.SetStateAction<reloadState>) => void,
+  setOverwriteDialogPlop: (
+    value: React.SetStateAction<OverwriteDialogPlop | undefined>
+  ) => void
 ) =>
   // subschema表示
   filteredSchemaIds.map((info: dispSchemaIdAndDocumentIdDefine) => {
@@ -70,6 +76,8 @@ export const createTab = (
           selectedTabKey={selectedTabKey}
           schemaAddModFunc={schemaAddModFunc}
           setUpdateFormData={setUpdateFormData}
+          setReload={setReload}
+          setOverwriteDialogPlop={setOverwriteDialogPlop}
         />
       </Tab>
     );
@@ -95,7 +103,11 @@ export const createTabs = (
   setChildTabSelectedFunc:
     | React.Dispatch<React.SetStateAction<ChildTabSelectedFuncObj>>
     | undefined,
-  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>
+  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>,
+  setReload: (value: React.SetStateAction<reloadState>) => void,
+  setOverwriteDialogPlop: (
+    value: React.SetStateAction<OverwriteDialogPlop | undefined>
+  ) => void
 ) => {
   // 選択中のタブeventKey
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -292,7 +304,9 @@ export const createTabs = (
             setErrors,
             selectedTabKey,
             onTabSelectEvent,
-            setUpdateFormData
+            setUpdateFormData,
+            setReload,
+            setOverwriteDialogPlop
           )}
 
           {/* childSchema表示 */}
@@ -309,7 +323,9 @@ export const createTabs = (
             setErrors,
             selectedTabKey,
             onTabSelectEvent,
-            setUpdateFormData
+            setUpdateFormData,
+            setReload,
+            setOverwriteDialogPlop
           )}
         </Tabs>
         <SaveConfirmDialog
@@ -338,7 +354,11 @@ export const createPanel = (
   selectedTabKey: any,
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void,
   parentTabsId: string,
-  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>
+  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>,
+  setReload: (value: React.SetStateAction<reloadState>) => void,
+  setOverwriteDialogPlop: (
+    value: React.SetStateAction<OverwriteDialogPlop | undefined>
+  ) => void
 ) =>
   // subschema表示
   filteredSchemaIds.map((info: dispSchemaIdAndDocumentIdDefine) => (
@@ -359,6 +379,8 @@ export const createPanel = (
       selectedTabKey={selectedTabKey}
       schemaAddModFunc={schemaAddModFunc}
       setUpdateFormData={setUpdateFormData}
+      setReload={setReload}
+      setOverwriteDialogPlop={setOverwriteDialogPlop}
     />
   ));
 
@@ -381,7 +403,11 @@ export const createPanels = (
   selectedTabKey: any,
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void,
   parentTabsId: string,
-  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>
+  setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>,
+  setReload: (value: React.SetStateAction<reloadState>) => void,
+  setOverwriteDialogPlop: (
+    value: React.SetStateAction<OverwriteDialogPlop | undefined>
+  ) => void
 ) =>
   (subschemaIdsNotDeleted.length > 0 ||
     dispChildSchemaIdsNotDeleted.length > 0) && (
@@ -397,7 +423,9 @@ export const createPanels = (
         selectedTabKey,
         schemaAddModFunc,
         parentTabsId,
-        setUpdateFormData
+        setUpdateFormData,
+        setReload,
+        setOverwriteDialogPlop
       )}
       {createPanel(
         dispChildSchemaIds,
@@ -410,7 +438,9 @@ export const createPanels = (
         selectedTabKey,
         schemaAddModFunc,
         parentTabsId,
-        setUpdateFormData
+        setUpdateFormData,
+        setReload,
+        setOverwriteDialogPlop
       )}
     </>
   );

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -26,6 +26,8 @@ import { Const } from '../../common/Const';
 import { JesgoDocumentSchema } from '../../store/schemaDataReducer';
 import { getEventDate, responseResult } from '../../common/DBUtility';
 import store from '../../store';
+import { reloadState } from '../../views/Registration';
+import { OverwriteDialogPlop } from '../common/PluginOverwriteConfirm';
 
 // 孫スキーマ以降
 type Props = {
@@ -45,6 +47,10 @@ type Props = {
   selectedTabKey: any;
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void;
   setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>;
+  setReload: (value: React.SetStateAction<reloadState>) => void;
+  setOverwriteDialogPlop: (
+    value: React.SetStateAction<OverwriteDialogPlop | undefined>
+  ) => void;
 };
 
 const PanelSchema = React.memo((props: Props) => {
@@ -63,6 +69,8 @@ const PanelSchema = React.memo((props: Props) => {
     selectedTabKey,
     schemaAddModFunc,
     setUpdateFormData,
+    setReload,
+    setOverwriteDialogPlop,
   } = props;
 
   const [formData, setFormData] = useState<any>({}); // eslint-disable-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-explicit-any
@@ -620,6 +628,8 @@ const PanelSchema = React.memo((props: Props) => {
           tabSelectEvents={childTabSelectedFunc}
           addableSubSchemaIds={addableSubSchemaIds}
           setIsLoading={setIsLoading}
+          setReload={setReload}
+          setOverwriteDialogPlop={setOverwriteDialogPlop}
         />
       </div>
       {isTab
@@ -637,7 +647,9 @@ const PanelSchema = React.memo((props: Props) => {
             setErrors,
             childTabSelectedFunc,
             setChildTabSelectedFunc,
-            setUpdateChildFormData
+            setUpdateChildFormData,
+            setReload,
+            setOverwriteDialogPlop
           )
         : // パネル表示
           createPanels(
@@ -653,7 +665,9 @@ const PanelSchema = React.memo((props: Props) => {
             selectedTabKey,
             schemaAddModFunc,
             parentTabsId,
-            setUpdateChildFormData
+            setUpdateChildFormData,
+            setReload,
+            setOverwriteDialogPlop
           )}
     </Panel>
   );

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -26,6 +26,8 @@ import { getEventDate, responseResult } from '../../common/DBUtility';
 import { JesgoDocumentSchema } from '../../store/schemaDataReducer';
 import store from '../../store';
 import { Const } from '../../common/Const';
+import { reloadState } from '../../views/Registration';
+import { OverwriteDialogPlop } from '../common/PluginOverwriteConfirm';
 
 type Props = {
   tabId: string;
@@ -43,6 +45,10 @@ type Props = {
   setErrors: React.Dispatch<React.SetStateAction<RegistrationErrors[]>>;
   selectedTabKey: any;
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void;
+  setReload: (value: React.SetStateAction<reloadState>) => void;
+  setOverwriteDialogPlop: (
+    value: React.SetStateAction<OverwriteDialogPlop | undefined>
+  ) => void;
 };
 
 // ルートディレクトリのスキーマ
@@ -60,6 +66,8 @@ const RootSchema = React.memo((props: Props) => {
     isSchemaChange,
     setErrors,
     schemaAddModFunc,
+    setReload,
+    setOverwriteDialogPlop,
   } = props;
 
   // 表示中のchild_schema
@@ -573,6 +581,8 @@ const RootSchema = React.memo((props: Props) => {
           tabSelectEvents={childTabSelectedFunc}
           addableSubSchemaIds={addableSubSchemaIds}
           setIsLoading={setIsLoading}
+          setReload={setReload}
+          setOverwriteDialogPlop={setOverwriteDialogPlop}
         />
       </div>
       {createTabs(
@@ -588,7 +598,9 @@ const RootSchema = React.memo((props: Props) => {
         setErrors,
         childTabSelectedFunc,
         setChildTabSelectedFunc,
-        setUpdateChildFormData
+        setUpdateChildFormData,
+        setReload,
+        setOverwriteDialogPlop
       )}
     </>
   );

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -26,6 +26,8 @@ import { Const } from '../../common/Const';
 import { getEventDate, responseResult } from '../../common/DBUtility';
 import '../../views/Registration.css';
 import store from '../../store';
+import { reloadState } from '../../views/Registration';
+import { OverwriteDialogPlop } from '../common/PluginOverwriteConfirm';
 
 // ルートディレクトリ直下の子スキーマ
 type Props = {
@@ -48,6 +50,10 @@ type Props = {
   selectedTabKey: any;
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void;
   setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>;
+  setReload: (value: React.SetStateAction<reloadState>) => void;
+  setOverwriteDialogPlop: (
+    value: React.SetStateAction<OverwriteDialogPlop | undefined>
+  ) => void;
 };
 
 const TabSchema = React.memo((props: Props) => {
@@ -69,6 +75,8 @@ const TabSchema = React.memo((props: Props) => {
     selectedTabKey,
     schemaAddModFunc,
     setUpdateFormData,
+    setReload,
+    setOverwriteDialogPlop,
   } = props;
 
   // 表示中のchild_schema
@@ -617,6 +625,8 @@ const TabSchema = React.memo((props: Props) => {
           tabSelectEvents={childTabSelectedFunc}
           addableSubSchemaIds={addableSubSchemaIds}
           setIsLoading={setIsLoading}
+          setReload={setReload}
+          setOverwriteDialogPlop={setOverwriteDialogPlop}
         />
       </div>
       {isTab
@@ -634,7 +644,9 @@ const TabSchema = React.memo((props: Props) => {
             setErrors,
             childTabSelectedFunc,
             setChildTabSelectedFunc,
-            setUpdateChildFormData
+            setUpdateChildFormData,
+            setReload,
+            setOverwriteDialogPlop
           )
         : // パネル表示
           createPanels(
@@ -650,7 +662,9 @@ const TabSchema = React.memo((props: Props) => {
             selectedTabKey,
             schemaAddModFunc,
             tabId,
-            setUpdateChildFormData
+            setUpdateChildFormData,
+            setReload,
+            setOverwriteDialogPlop
           )}
     </>
   );

--- a/src/components/common/PluginButton.tsx
+++ b/src/components/common/PluginButton.tsx
@@ -43,9 +43,7 @@ const PluginButton = (props: {
       }
       case PAGE_TYPE.TARGET_PATIENT: {
         setTargetPlugins(
-          pluginList.filter(
-            (p) => !p.all_patient && (!p.target_schema_id || p.update_db)
-          )
+          pluginList.filter((p) => !p.all_patient && !p.target_schema_id)
         );
         break;
       }

--- a/src/views/Registration.tsx
+++ b/src/views/Registration.tsx
@@ -62,6 +62,10 @@ import {
   ShowSaveDialogState,
   RegistrationErrors,
 } from '../components/CaseRegistration/Definition';
+import {
+  PluginOverwriteConfirm,
+  OverwriteDialogPlop,
+} from '../components/common/PluginOverwriteConfirm';
 
 export type reloadState = {
   isReload: boolean;
@@ -115,6 +119,11 @@ const Registration = () => {
   const [decline, setDecline] = useState<boolean>(false);
 
   const [isSaved, setIsSaved] = useState(false); // 保存済みフラグ
+
+  // プラグイン用上書き確認ダイアログ
+  const [overwriteDialogPlop, setOverwriteDialogPlop] = useState<
+    OverwriteDialogPlop | undefined
+  >();
 
   let age = ''; // 年齢
 
@@ -624,175 +633,187 @@ const Registration = () => {
   }, [hasSchema]);
 
   return (
-    <div className="page-area">
-      {/* 患者情報入力 */}
-      <div className="patient-area">
-        <Panel className="panel-style patient-area-panel">
-          <Row className="patientInfo user-info-row">
-            <Col className="user-info-col">
-              <FormGroup controlId="patientId">
-                <ControlLabel>患者ID：</ControlLabel>
-                <FormControl
-                  type="text"
-                  onChange={onChangeItem}
-                  value={patientId}
-                  readOnly={isSaved}
-                  autoComplete="off"
-                />
-              </FormGroup>
-            </Col>
-            <Col className="user-info-col">
-              <FormGroup controlId="patientName">
-                <ControlLabel>患者氏名：</ControlLabel>
-                <FormControl
-                  type="text"
-                  onChange={onChangeItem}
-                  value={patientName}
-                  autoComplete="off"
-                />
-              </FormGroup>
-            </Col>
-            <Col className="user-info-col">
-              <FormGroup controlId="birthday">
-                <ControlLabel>生年月日</ControlLabel>
-                <FormControl
-                  type="date"
-                  min={Const.INPUT_DATE_MIN}
-                  max={Const.INPUT_DATE_MAX()}
-                  onChange={onChangeItem}
-                  value={birthday}
-                />
-              </FormGroup>
-            </Col>
-            <Col className="user-info-age">
-              <FormGroup>
-                <ControlLabel>年齢</ControlLabel>
-                <div>
-                  <FormControl.Static className="user-info-age">
-                    {age}歳
-                  </FormControl.Static>
-                </div>
-              </FormGroup>
-            </Col>
-            <Col>
-              <FormGroup>
-                <ControlLabel />
-                <div>
-                  <Checkbox
-                    className="user-info-checkbox"
-                    id="decline"
-                    onChange={onChangeItem}
-                    checked={decline}
-                  >
-                    登録拒否
-                  </Checkbox>
-                </div>
-              </FormGroup>
-            </Col>
-          </Row>
-          <SubmitButton
-            setIsLoading={setIsLoading}
-            setLoadedJesgoCase={setLoadedJesgoCase}
-            setCaseId={setCaseId}
-            setReload={setReload}
-            setErrors={setErrors}
-          />
-        </Panel>
-      </div>
-      {!isLoading && hasSchema && (
-        <>
-          {message.length > 0 && (
-            <Panel className="error-msg-panel">
-              {message.map((error: string) => (
-                <p key={error}>
-                  {error.split('\n').map((item, index) => (
-                    <>
-                      {index > 0 && <br />}
-                      {item}
-                    </>
-                  ))}
-                </p>
-              ))}
-            </Panel>
-          )}
-          <div className="content-area">
-            <div className="input-form">
-              {dispRootSchemaIdsNotDeleted.length > 0 && (
-                <Tabs
-                  id="root-tabs"
-                  activeKey={selectedTabKey} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-                  onSelect={(eventKey) => onTabSelectEvent(true, eventKey)}
-                >
-                  {dispRootSchemaIdsNotDeleted.map(
-                    (info: dispSchemaIdAndDocumentIdDefine) => {
-                      const title =
-                        info.title + (info.titleNum?.toString() ?? '');
-
-                      // TODO TabSchemaにTabを置くとうまく動作しなくなる
-                      return (
-                        <Tab
-                          key={`root-tab-${info.compId}`}
-                          className="panel-style"
-                          eventKey={`root-tab-${info.compId}`}
-                          title={<span>{title}</span>}
-                        >
-                          <RootSchema
-                            key={`root-${info.compId}`}
-                            tabId={`root-tab-${info.compId}`}
-                            parentTabsId="root-tab"
-                            schemaId={info.schemaId}
-                            documentId={info.documentId}
-                            dispSchemaIds={[...dispRootSchemaIds]}
-                            setDispSchemaIds={setDispRootSchemaIds}
-                            setSelectedTabKey={setSelectedTabKey}
-                            setIsLoading={setIsLoading}
-                            setSaveResponse={setSaveResponse}
-                            isSchemaChange={info.isSchemaChange}
-                            setErrors={setErrors}
-                            selectedTabKey={selectedTabKey}
-                            schemaAddModFunc={onTabSelectEvent}
-                          />
-                        </Tab>
-                      );
-                    }
-                  )}
-                </Tabs>
-              )}
-            </div>
-            <ControlButton
-              tabId="root-tab"
-              parentTabsId=""
-              Type={COMP_TYPE.ROOT}
-              isChildSchema={false} // eslint-disable-line react/jsx-boolean-value
-              schemaId={0}
-              dispSubSchemaIds={[]}
-              dispChildSchemaIds={[...dispRootSchemaIds]}
-              setDispSubSchemaIds={undefined}
-              setDispChildSchemaIds={setDispRootSchemaIds}
-              dispatch={dispatch}
-              documentId=""
-              subSchemaCount={0}
-              tabSelectEvents={{
-                fnAddDocument: onTabSelectEvent,
-                fnSchemaChange: undefined,
-              }}
-              disabled={!isSaved}
-              setIsLoading={setIsLoading}
-            />
-          </div>
-        </>
+    <>
+      {overwriteDialogPlop && (
+        <PluginOverwriteConfirm
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...overwriteDialogPlop}
+        />
       )}
-      {/* ローディング画面表示 */}
-      {(isLoading || !hasSchema) && <Loading />}
-      {/* 保存確認ダイアログ */}
-      <SaveConfirmDialog
-        show={showSaveDialog}
-        onOk={() => saveDialogOk(showSaveDialog.eventKey)}
-        onCancel={() => saveDialogCancel(showSaveDialog.eventKey)}
-        title="JESGO"
-        message="保存します。よろしいですか？"
-      />
-    </div>
+      <div className="page-area">
+        {/* 患者情報入力 */}
+        <div className="patient-area">
+          <Panel className="panel-style patient-area-panel">
+            <Row className="patientInfo user-info-row">
+              <Col className="user-info-col">
+                <FormGroup controlId="patientId">
+                  <ControlLabel>患者ID：</ControlLabel>
+                  <FormControl
+                    type="text"
+                    onChange={onChangeItem}
+                    value={patientId}
+                    readOnly={isSaved}
+                    autoComplete="off"
+                  />
+                </FormGroup>
+              </Col>
+              <Col className="user-info-col">
+                <FormGroup controlId="patientName">
+                  <ControlLabel>患者氏名：</ControlLabel>
+                  <FormControl
+                    type="text"
+                    onChange={onChangeItem}
+                    value={patientName}
+                    autoComplete="off"
+                  />
+                </FormGroup>
+              </Col>
+              <Col className="user-info-col">
+                <FormGroup controlId="birthday">
+                  <ControlLabel>生年月日</ControlLabel>
+                  <FormControl
+                    type="date"
+                    min={Const.INPUT_DATE_MIN}
+                    max={Const.INPUT_DATE_MAX()}
+                    onChange={onChangeItem}
+                    value={birthday}
+                  />
+                </FormGroup>
+              </Col>
+              <Col className="user-info-age">
+                <FormGroup>
+                  <ControlLabel>年齢</ControlLabel>
+                  <div>
+                    <FormControl.Static className="user-info-age">
+                      {age}歳
+                    </FormControl.Static>
+                  </div>
+                </FormGroup>
+              </Col>
+              <Col>
+                <FormGroup>
+                  <ControlLabel />
+                  <div>
+                    <Checkbox
+                      className="user-info-checkbox"
+                      id="decline"
+                      onChange={onChangeItem}
+                      checked={decline}
+                    >
+                      登録拒否
+                    </Checkbox>
+                  </div>
+                </FormGroup>
+              </Col>
+            </Row>
+            <SubmitButton
+              setIsLoading={setIsLoading}
+              setLoadedJesgoCase={setLoadedJesgoCase}
+              setCaseId={setCaseId}
+              setReload={setReload}
+              setErrors={setErrors}
+            />
+          </Panel>
+        </div>
+        {!isLoading && hasSchema && (
+          <>
+            {message.length > 0 && (
+              <Panel className="error-msg-panel">
+                {message.map((error: string) => (
+                  <p key={error}>
+                    {error.split('\n').map((item, index) => (
+                      <>
+                        {index > 0 && <br />}
+                        {item}
+                      </>
+                    ))}
+                  </p>
+                ))}
+              </Panel>
+            )}
+            <div className="content-area">
+              <div className="input-form">
+                {dispRootSchemaIdsNotDeleted.length > 0 && (
+                  <Tabs
+                    id="root-tabs"
+                    activeKey={selectedTabKey} // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+                    onSelect={(eventKey) => onTabSelectEvent(true, eventKey)}
+                  >
+                    {dispRootSchemaIdsNotDeleted.map(
+                      (info: dispSchemaIdAndDocumentIdDefine) => {
+                        const title =
+                          info.title + (info.titleNum?.toString() ?? '');
+
+                        // TODO TabSchemaにTabを置くとうまく動作しなくなる
+                        return (
+                          <Tab
+                            key={`root-tab-${info.compId}`}
+                            className="panel-style"
+                            eventKey={`root-tab-${info.compId}`}
+                            title={<span>{title}</span>}
+                          >
+                            <RootSchema
+                              key={`root-${info.compId}`}
+                              tabId={`root-tab-${info.compId}`}
+                              parentTabsId="root-tab"
+                              schemaId={info.schemaId}
+                              documentId={info.documentId}
+                              dispSchemaIds={[...dispRootSchemaIds]}
+                              setDispSchemaIds={setDispRootSchemaIds}
+                              setSelectedTabKey={setSelectedTabKey}
+                              setIsLoading={setIsLoading}
+                              setSaveResponse={setSaveResponse}
+                              isSchemaChange={info.isSchemaChange}
+                              setErrors={setErrors}
+                              selectedTabKey={selectedTabKey}
+                              schemaAddModFunc={onTabSelectEvent}
+                              setReload={setReload}
+                              setOverwriteDialogPlop={setOverwriteDialogPlop}
+                            />
+                          </Tab>
+                        );
+                      }
+                    )}
+                  </Tabs>
+                )}
+              </div>
+              <ControlButton
+                tabId="root-tab"
+                parentTabsId=""
+                Type={COMP_TYPE.ROOT}
+                isChildSchema={false} // eslint-disable-line react/jsx-boolean-value
+                schemaId={0}
+                dispSubSchemaIds={[]}
+                dispChildSchemaIds={[...dispRootSchemaIds]}
+                setDispSubSchemaIds={undefined}
+                setDispChildSchemaIds={setDispRootSchemaIds}
+                dispatch={dispatch}
+                documentId=""
+                subSchemaCount={0}
+                tabSelectEvents={{
+                  fnAddDocument: onTabSelectEvent,
+                  fnSchemaChange: undefined,
+                }}
+                disabled={!isSaved}
+                setIsLoading={setIsLoading}
+                setReload={setReload}
+                setOverwriteDialogPlop={setOverwriteDialogPlop}
+              />
+            </div>
+          </>
+        )}
+        {/* ローディング画面表示 */}
+        {(isLoading || !hasSchema) && <Loading />}
+        {/* 保存確認ダイアログ */}
+        <SaveConfirmDialog
+          show={showSaveDialog}
+          onOk={() => saveDialogOk(showSaveDialog.eventKey)}
+          onCancel={() => saveDialogCancel(showSaveDialog.eventKey)}
+          title="JESGO"
+          message="保存します。よろしいですか？"
+        />
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
#229 の対応、更新対象はドキュメント単位(子を含まず)に指定。
更新があるのはフロントエンドのみ。