### PR TITLE
accept targetDocument=0

### DIFF
--- a/src/common/Plugin.ts
+++ b/src/common/Plugin.ts
@@ -195,7 +195,7 @@ const updatePatientsDocument = async (
       );
       return;
     }
-    if (!(doc as argDoc).targetDocument) {
+    if (Number.isNaN(Number((doc as argDoc).targetDocument))) {
       alert(
         '更新系プラグインからのpackagedドキュメント取得にはdocument_idの指定が必須です'
       );


### PR DESCRIPTION
更新系プラグインからの取得リクエストで、document_idの判定が !doc.targetDocument でされており型判定が無いのと目的としてundefinedを弾くのかがはっきりしていないので本当は整数だが少なくとも数値型だけを通すように明確化。

_これで、（本当はイケナイ）マジックナンバー0 = (root) での取得が可能になります。_