### PR TITLE
更新系プラグインからのドキュメント取得で targetDocument = 0 に対応

### DIFF
--- a/src/common/Plugin.ts
+++ b/src/common/Plugin.ts
@@ -195,7 +195,7 @@ const updatePatientsDocument = async (
       );
       return;
     }
-    if (!(doc as argDoc).targetDocument) {
+    if (Number.isNaN(Number((doc as argDoc).targetDocument))) {
       alert(
         '更新系プラグインからのpackagedドキュメント取得にはdocument_idの指定が必須です'
       );


### PR DESCRIPTION
更新系プラグインでのドキュメント取得で、doc.targetDocumentの判定がundefinedを弾きたい目的だが、マジックナンバーであるtargetDocument=0も弾いてしまっていたので若干厳密に対応。

- マジックナンバー使用の是非は将来への課題