### PR TITLE
jesgo:require が指定されたフィールドについて、入力項目の背景色をハイライトする

### DIFF
--- a/src/components/CaseRegistration/JESGOComponent.css
+++ b/src/components/CaseRegistration/JESGOComponent.css
@@ -104,3 +104,17 @@ li.layer-combobox-item div {
   font-family: 'BIZ-UDPGothic' !important;
 }
 /* 階層表示用コンボボックス向けCSS end */
+
+/* jesgo:require ハイライト start */
+.jesgo-require select,
+.jesgo-require textarea,
+.jesgo-require .checkboxes,
+.jesgo-require .field-radio-group,
+.jesgo-require .MuiInputBase-root,
+.jesgo-require input {
+  background: 
+  linear-gradient(90deg, transparent 95%, pink), 
+  linear-gradient(270deg, transparent 95%, pink), 
+  linear-gradient(0deg, transparent 65%, pink), 
+  linear-gradient(180deg, transparent 65%, pink)
+}

--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -136,7 +136,7 @@ const CustomDivForm = (props: CustomDivFormProp) => {
   copyProps.formData = formData;
 
   // uiSchema作成
-  const uiSchema = CreateUISchema(schema);
+  const uiSchema = CreateUISchema(schema, formData);
   if (isTabItem) {
     uiSchema['ui:ObjectFieldTemplate'] =
       JESGOFiledTemplete.TabItemFieldTemplate;

--- a/src/components/CaseRegistration/UISchemaUtility.tsx
+++ b/src/components/CaseRegistration/UISchemaUtility.tsx
@@ -10,6 +10,8 @@ import lodash from 'lodash';
 import { JESGOFiledTemplete } from './JESGOFieldTemplete';
 import { Const } from '../../common/Const';
 import { getPropItemsAndNames, getSchemaType } from './SchemaUtility';
+import { isNotEmptyObject } from '../../common/CaseRegistrationUtility';
+import store from '../../store';
 
 // uiSchema作成用Utility
 
@@ -27,6 +29,7 @@ export type UiSchemaProp = {
 const AddUiSchema = (
   schema: JSONSchema7,
   uiSchema: UiSchema,
+  formData: any,
   isRequired: boolean
 ) => {
   let resultUiSchema: UiSchema = lodash.cloneDeep(uiSchema);
@@ -74,6 +77,13 @@ const AddUiSchema = (
   // "jesgo:ui:visiblewhen"
   if (schema[Const.EX_VOCABULARY.UI_VISIBLE_WHEN]) {
     classNames.push('visiblewhen');
+  }
+  
+  // "jesgo:required"
+  const jesgoRequireds = schema[Const.EX_VOCABULARY.REQUIRED];
+  if (jesgoRequireds && !isNotEmptyObject(formData) &&
+    store.getState().commonReducer.isJesgoRequiredHighlight) {
+    classNames.push('jesgo-require');
   }
 
   // "jesgo:required"、または"description"がある場合、カスタムラベルを使用
@@ -268,6 +278,7 @@ export const createUiSchemaProperties = (
   propNames: string[],
   items: { [key: string]: JSONSchema7Definition },
   uiSchema: UiSchema,
+  formData: any,
   orderList: string[]
 ) => {
   let resUiSchema: UiSchema = lodash.cloneDeep(uiSchema);
@@ -278,11 +289,14 @@ export const createUiSchemaProperties = (
 
   propNames.forEach((propName: string) => {
     const item = items[propName] as JSONSchema7;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const targetFormData = formData != null ? formData[propName] : "";
 
     // 直下のproperties
     resUiSchema[propName] = AddUiSchema(
       item,
       resUiSchema[propName] as UiSchema,
+      targetFormData,
       requiredNames.includes(propName)
     );
     CreateOrderList(orderList, propName);
@@ -299,6 +313,7 @@ export const createUiSchemaProperties = (
         childPropNames,
         childItems,
         resUiSchema[propName] as UiSchema,
+        targetFormData,
         orderList
       );
     } else if (type === Const.JSONSchema7Types.ARRAY) {
@@ -307,11 +322,14 @@ export const createUiSchemaProperties = (
 
       // TODO childItemが配列だった場合の判定はしていない。現状のスキーマにもない。要制限事項
       const propItem = getPropItemsAndNames(childItem as JSONSchema7);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const itemsFormData = formData != null ? formData[propName] : "";
       let itemsUiSchema = lodash.cloneDeep(resUiSchema[propName]) as UiSchema;
 
       itemsUiSchema = AddUiSchema(
         childItem as JSONSchema7,
         itemsUiSchema,
+        itemsFormData,
         requiredNames.includes(propName)
       );
 
@@ -320,6 +338,7 @@ export const createUiSchemaProperties = (
         propItem.pNames,
         propItem.pItems,
         itemsUiSchema,
+        itemsFormData,
         orderList
       );
 
@@ -339,11 +358,11 @@ export const createUiSchemaProperties = (
  * @param schema
  * @returns
  */
-export const CreateUISchema = (schema: JSONSchema7) => {
+export const CreateUISchema = (schema: JSONSchema7, formData: any) => {
   let uiSchema: UiSchema = {};
   const orderList: string[] = [];
   // ルート
-  uiSchema = AddUiSchema(schema, uiSchema, false);
+  uiSchema = AddUiSchema(schema, uiSchema, formData, false);
 
   // ルートのitems
   const rootPropsName = Object.keys(schema);
@@ -371,6 +390,7 @@ export const CreateUISchema = (schema: JSONSchema7) => {
             propItems.pNames,
             propItems.pItems,
             uiSchema,
+            formData,
             orderList
           );
         }
@@ -383,6 +403,7 @@ export const CreateUISchema = (schema: JSONSchema7) => {
           propItems.pNames,
           propItems.pItems,
           uiSchema,
+          formData,
           orderList
         );
       }
@@ -397,6 +418,7 @@ export const CreateUISchema = (schema: JSONSchema7) => {
       Object.keys(properties),
       properties,
       uiSchema,
+      formData,
       orderList
     );
   }
@@ -425,9 +447,12 @@ export const CreateUISchema = (schema: JSONSchema7) => {
                 oneOfItemNames.forEach((oneOfItemName: string) => {
                   // TODO dependenciesに同項目に対し条件が複数あるとおかしくなる（uischemaが重複する）。要修正
                   if (oneOfItemName !== depName) {
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+                    const targetFormData = formData != null ? formData[oneOfItemName] : "";
                     uiSchema[oneOfItemName] = AddUiSchema(
                       oneOfItemProp[oneOfItemName] as JSONSchema7,
                       uiSchema[oneOfItemName] as UiSchema,
+                      targetFormData,
                       oneOfRequired.includes(oneOfItemName)
                     );
                     CreateOrderList(orderList, oneOfItemName, depName);

--- a/src/store/commonReducer.ts
+++ b/src/store/commonReducer.ts
@@ -12,6 +12,7 @@ export interface commonState {
   isSaveAfterTabbing?: boolean; // タブ移動時の保存有無
   isShownSaveMessage?: boolean; // 保存確認ダイアログ表示中フラグ
   subSchemaCount?: number; // 自動生成されるサブスキーマの個数
+  isJesgoRequiredHighlight?:boolean;  // jesgo:required 未入力時ハイライト
 
   pluginList?: jesgoPluginColumns[];
 }
@@ -22,6 +23,7 @@ export interface commonAction {
   isHiddenSaveMassage?: boolean;
   isSaveAfterTabbing?: boolean;
   isShownSaveMessage?: boolean;
+  isJesgoRequiredHighlight?: boolean;
 
   pluginList?: jesgoPluginColumns[];
 }
@@ -31,6 +33,7 @@ const createInitialState = (): commonState => ({
   isHiddenSaveMassage: false,
   isSaveAfterTabbing: false,
   isShownSaveMessage: false,
+  isJesgoRequiredHighlight: false,
   pluginList: undefined,
 });
 
@@ -65,6 +68,12 @@ const commonReducer: Reducer<commonState, commonAction> = (
     // 保存ダイアログ表示中フラグの更新
     case 'SHOWN_SAVE_MESSAGE': {
       copyState.isShownSaveMessage = action.isShownSaveMessage;
+      break;
+    }
+
+    // 保存ダイアログ表示中フラグの更新
+    case 'JESGO_REQUIRED_HIGHLIGHT': {
+      copyState.isJesgoRequiredHighlight = action.isJesgoRequiredHighlight;
       break;
     }
 

--- a/src/views/Registration.css
+++ b/src/views/Registration.css
@@ -77,6 +77,13 @@ body {
   /* padding-top: 10px; */
 }
 
+.setting-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: 20px;
+  /* padding-top: 10px; */
+}
+
 .user-info-col {
   min-width: 200px;
   margin-left: 20px;

--- a/src/views/Registration.tsx
+++ b/src/views/Registration.tsx
@@ -21,6 +21,7 @@ import {
   Checkbox,
   Button,
   Glyphicon,
+  Radio,
 } from 'react-bootstrap';
 import jsonpatch, { JSONPatch } from 'jsonpatch';
 import {
@@ -131,6 +132,9 @@ const Registration = () => {
   >();
 
   let age = ''; // 年齢
+
+  // jesgo:requiredのハイライト設定
+  const [highlight, setHighlight] = useState<boolean>(false);
 
   // 選択中のタブeventKey
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -638,6 +642,19 @@ const Registration = () => {
     }
   }, [hasSchema]);
 
+  const handleSettingHighlight = (event: any) => {
+    const eventTarget: EventTarget & HTMLInputElement =
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      event.target as EventTarget & HTMLInputElement;
+    if (eventTarget.value === 'true') {
+      dispatch({ type: 'JESGO_REQUIRED_HIGHLIGHT', isJesgoRequiredHighlight: true });
+      setHighlight(true);
+    } else {
+      dispatch({ type: 'JESGO_REQUIRED_HIGHLIGHT', isJesgoRequiredHighlight: false });
+      setHighlight(false);
+    }
+  };
+
   return (
     <>
       {overwriteDialogPlop && (
@@ -708,6 +725,33 @@ const Registration = () => {
                     >
                       登録拒否
                     </Checkbox>
+                  </div>
+                </FormGroup>
+              </Col>
+            </Row>
+            <Row className="setting-row">
+              <Col>
+                <FormGroup>
+                  <ControlLabel>JSOG/JSGOE必須項目ハイライト</ControlLabel>
+                  <div>
+                    <Radio
+                      name="jesgo_required_highlight"
+                      onChange={handleSettingHighlight}
+                      value="true"
+                      inline
+                      checked={highlight}
+                    >
+                      あり
+                    </Radio>
+                    <Radio
+                      name="jesgo_required_highlight"
+                      onChange={handleSettingHighlight}
+                      value="false"
+                      inline
+                      checked={!highlight}
+                    >
+                      なし
+                    </Radio>
                   </div>
                 </FormGroup>
               </Col>


### PR DESCRIPTION
[frontend] 新規実装要求 #252　の対応。
2024年項目改定で追加された項目についても動作確認済み。

※制限事項
- "jesgo:ui:listtype": "suggestcombo"（リストからの選択の他、フリー記載を許容するコンボボックス）
- oneOfを使用した階層付きラジオボタン
- 複数チェックボックス

現状、上記3つのプロパティが背景色がつきません。上二つはJSOGのラベルも出ません。
ただ、2024年項目改定後のスキーマでは、これらにjesgo:requiredを設定してはいないので、見かけ上の影響はないです。
別途対応します。