### PR TITLE
#284 suggestlist、suggestcomboの選択肢検索仕様変更

### DIFF
--- a/src/components/CaseRegistration/JESGOComponent.tsx
+++ b/src/components/CaseRegistration/JESGOComponent.tsx
@@ -738,6 +738,11 @@ export namespace JESGOComp {
               return options;
             }
 
+            // 入力値と完全一致するリストがある = リストから選択済み と見なし、選択肢の検索をしない
+            if (options.find((op) => (op.label ?? '') === state.inputValue)) {
+              return options;
+            }
+
             // 同一グループのタイトルは表示させる
             const groupIds = options
               // .filter((op) => (op.label ?? '').startsWith(state.inputValue)) // 前方一致


### PR DESCRIPTION
#284 にて上がった課題の対応
- suggestlistおよびsuggestcombo使用時の選択肢検索時、入力値が選択肢と完全一致の場合は検索を行わず、すべての選択肢を表示するよう修正