### PR TITLE
親のeventdate変更による子スキーマ切り替え対応

### DIFF
--- a/src/common/DBUtility.ts
+++ b/src/common/DBUtility.ts
@@ -276,10 +276,17 @@ export const checkEventDateInfinityLoop = (
   return ret;
 };
 
-// event_date取得処理
+/**
+ * event_date取得処理
+ * @param jesgoDoc 
+ * @param formData 
+ * @param isRecursion true:再帰呼び出し false:非再帰呼び出し
+ * @returns 
+ */
 export const getEventDate = (
   jesgoDoc: jesgoDocumentObjDefine,
-  formData: any
+  formData: any,
+  isRecursion = false
 ): string => {
   let eventDate = '';
 
@@ -347,7 +354,12 @@ export const getEventDate = (
     );
     if (parentDoc) {
       // 見つかるまでルートまで探索
-      eventDate = getEventDate(parentDoc, parentDoc.value.document);
+      eventDate = getEventDate(parentDoc, parentDoc.value.document, true);
+    }
+
+    // ルートまで遡って見つからない場合、ドキュメントの作成日を使用する
+    if (!isRecursion && !eventDate) {
+      eventDate = formatDateStr(jesgoDoc.value.created, '-');
     }
   }
 

--- a/src/components/CaseRegistration/FormCommonComponents.tsx
+++ b/src/components/CaseRegistration/FormCommonComponents.tsx
@@ -26,6 +26,7 @@ import TabSchema from './TabSchema';
 
 export const createTab = (
   parentTabsId: string,
+  parentEventDate: string | null,
   schemaIds: dispSchemaIdAndDocumentIdDefine[],
   filteredSchemaIds: dispSchemaIdAndDocumentIdDefine[],
   setSchemaIds: React.Dispatch<
@@ -61,6 +62,7 @@ export const createTab = (
           key={`tabitem-${info.compId}`}
           tabId={`${parentTabsId}-tab-${info.compId}`}
           parentTabsId={parentTabsId}
+          parentEventDate={parentEventDate}
           isChildSchema={isChildSchema}
           schemaId={info.schemaId}
           documentId={info.documentId}
@@ -85,6 +87,7 @@ export const createTab = (
 
 export const createTabs = (
   id: string,
+  parentEventDate: string | null,
   subschemaIds: dispSchemaIdAndDocumentIdDefine[],
   subschemaIdsNotDeleted: dispSchemaIdAndDocumentIdDefine[],
   setSubschemaIds: React.Dispatch<
@@ -293,6 +296,7 @@ export const createTabs = (
           {/* subschema表示 */}
           {createTab(
             id,
+            parentEventDate,
             subschemaIds,
             subschemaIdsNotDeleted,
             setSubschemaIds,
@@ -312,6 +316,7 @@ export const createTabs = (
           {/* childSchema表示 */}
           {createTab(
             id,
+            parentEventDate,
             dispChildSchemaIds,
             dispChildSchemaIdsNotDeleted,
             setDispChildSchemaIds,
@@ -354,6 +359,7 @@ export const createPanel = (
   selectedTabKey: any,
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void,
   parentTabsId: string,
+  parentEventDate: string | null,
   setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>,
   setReload: (value: React.SetStateAction<reloadState>) => void,
   setOverwriteDialogPlop: (
@@ -366,6 +372,7 @@ export const createPanel = (
     <PanelSchema
       key={`panel-${info.compId}`}
       parentTabsId={parentTabsId}
+      parentEventDate={parentEventDate}
       isChildSchema={isChildSchema} // eslint-disable-line react/jsx-boolean-value
       schemaId={info.schemaId}
       documentId={info.documentId}
@@ -403,6 +410,7 @@ export const createPanels = (
   selectedTabKey: any,
   schemaAddModFunc: (isTabSelected: boolean, eventKey: any) => void,
   parentTabsId: string,
+  parentEventDate: string | null,
   setUpdateFormData: React.Dispatch<React.SetStateAction<boolean>>,
   setReload: (value: React.SetStateAction<reloadState>) => void,
   setOverwriteDialogPlop: (
@@ -423,6 +431,7 @@ export const createPanels = (
         selectedTabKey,
         schemaAddModFunc,
         parentTabsId,
+        parentEventDate,
         setUpdateFormData,
         setReload,
         setOverwriteDialogPlop
@@ -438,6 +447,7 @@ export const createPanels = (
         selectedTabKey,
         schemaAddModFunc,
         parentTabsId,
+        parentEventDate,
         setUpdateFormData,
         setReload,
         setOverwriteDialogPlop

--- a/src/components/CaseRegistration/PanelSchema.tsx
+++ b/src/components/CaseRegistration/PanelSchema.tsx
@@ -33,6 +33,7 @@ import { OverwriteDialogPlop } from '../common/PluginOverwriteConfirm';
 type Props = {
   schemaId: number;
   parentTabsId: string;
+  parentEventDate: string | null;
   setDispSchemaIds: React.Dispatch<
     React.SetStateAction<dispSchemaIdAndDocumentIdDefine[]>
   >;
@@ -56,6 +57,7 @@ type Props = {
 const PanelSchema = React.memo((props: Props) => {
   const {
     schemaId,
+    parentEventDate,
     parentTabsId,
     setDispSchemaIds,
     dispSchemaIds,
@@ -80,7 +82,7 @@ const PanelSchema = React.memo((props: Props) => {
     .formDataReducer.saveData.jesgo_document.find((p) => p.key === documentId);
   const eventDate = useMemo(
     () => (saveDoc ? getEventDate(saveDoc, formData) : null),
-    [saveDoc, formData]
+    [saveDoc, formData, parentEventDate]
   );
 
   // schemaIdをもとに情報を取得
@@ -212,7 +214,7 @@ const PanelSchema = React.memo((props: Props) => {
           schemaInfo: itemSchemaInfo,
           setAddedDocumentCount,
           isNotUniqueSubSchemaAdded: true,
-          schemaIndex: newItemIdx
+          schemaIndex: newItemIdx,
         });
       }
     } else if (
@@ -639,6 +641,7 @@ const PanelSchema = React.memo((props: Props) => {
         ? // タブ表示
           createTabs(
             parentTabsId,
+            eventDate,
             dispSubSchemaIds,
             dispSubSchemaIdsNotDeleted,
             setDispSubSchemaIds,
@@ -668,6 +671,7 @@ const PanelSchema = React.memo((props: Props) => {
             selectedTabKey,
             schemaAddModFunc,
             parentTabsId,
+            eventDate,
             setUpdateChildFormData,
             setReload,
             setOverwriteDialogPlop

--- a/src/components/CaseRegistration/RootSchema.tsx
+++ b/src/components/CaseRegistration/RootSchema.tsx
@@ -197,7 +197,7 @@ const RootSchema = React.memo((props: Props) => {
           schemaInfo: itemSchemaInfo,
           setAddedDocumentCount,
           isNotUniqueSubSchemaAdded: true,
-          schemaIndex: newItemIdx
+          schemaIndex: newItemIdx,
         });
       }
     } else if (
@@ -590,6 +590,7 @@ const RootSchema = React.memo((props: Props) => {
       </div>
       {createTabs(
         tabId,
+        eventDate,
         dispSubSchemaIds,
         dispSubSchemaIdsNotDeleted,
         setDispSubSchemaIds,

--- a/src/components/CaseRegistration/TabSchema.tsx
+++ b/src/components/CaseRegistration/TabSchema.tsx
@@ -33,6 +33,7 @@ import { OverwriteDialogPlop } from '../common/PluginOverwriteConfirm';
 type Props = {
   tabId: string;
   parentTabsId: string;
+  parentEventDate: string | null;
   schemaId: number;
   dispSchemaIds: dispSchemaIdAndDocumentIdDefine[];
   setDispSchemaIds: React.Dispatch<
@@ -60,6 +61,7 @@ const TabSchema = React.memo((props: Props) => {
   const {
     tabId,
     parentTabsId,
+    parentEventDate,
     schemaId,
     dispSchemaIds,
     setDispSchemaIds,
@@ -108,7 +110,7 @@ const TabSchema = React.memo((props: Props) => {
     .formDataReducer.saveData.jesgo_document.find((p) => p.key === documentId);
   const eventDate = useMemo(
     () => (saveDoc ? getEventDate(saveDoc, formData) : null),
-    [saveDoc, formData]
+    [saveDoc, formData, parentEventDate]
   );
 
   // schemaIdをもとに情報を取得
@@ -208,7 +210,7 @@ const TabSchema = React.memo((props: Props) => {
           schemaInfo: itemSchemaInfo,
           setAddedDocumentCount,
           isNotUniqueSubSchemaAdded: true,
-          schemaIndex: newItemIdx
+          schemaIndex: newItemIdx,
         });
       }
     } else if (
@@ -636,6 +638,7 @@ const TabSchema = React.memo((props: Props) => {
         ? // タブ表示
           createTabs(
             tabId,
+            eventDate,
             dispSubSchemaIds,
             dispSubSchemaIdsNotDeleted,
             setDispSubSchemaIds,
@@ -665,6 +668,7 @@ const TabSchema = React.memo((props: Props) => {
             selectedTabKey,
             schemaAddModFunc,
             tabId,
+            eventDate,
             setUpdateChildFormData,
             setReload,
             setOverwriteDialogPlop

--- a/src/store/formDataReducer.ts
+++ b/src/store/formDataReducer.ts
@@ -35,6 +35,7 @@ export type jesgoDocumentValueItem = {
   schema_primary_id: number;
   schema_major_version: number;
   registrant: number;
+  created: string;
   last_updated: string;
   readonly: boolean;
   deleted: boolean;
@@ -217,6 +218,7 @@ const createJesgoDocumentValueItem = (
     schema_primary_id: -1,
     schema_major_version: -1,
     registrant: -1,
+    created: '',
     last_updated: '',
     readonly: false,
     deleted: false,
@@ -247,7 +249,8 @@ const createJesgoDocumentValueItem = (
 
   // ログインユーザID
   valueItem.registrant = getLoginUserId();
-  valueItem.last_updated = new Date().toLocaleString('ja-JP');
+  valueItem.created = new Date().toLocaleString('ja-JP');
+  valueItem.last_updated = valueItem.created;
 
   return valueItem;
 };


### PR DESCRIPTION
https://github.com/jesgo-toitu/jesgo-frontend/issues/283
上記の課題に対する修正
- 親のeventdate変更時に子ドキュメントのスキーマを再描画する対応
- ドキュメント作成時にcreated(作成日)をセットする対応
- ルートドキュメントまで遡りeventdateが見つからなかった場合、createdをeventdateとする対応