### PR TITLE
IME全角にして患者一覧の日付の検索条件を入力すると挙動がおかしくなる問題を修正

### DIFF
--- a/src/components/common/SearchDateComponent.tsx
+++ b/src/components/common/SearchDateComponent.tsx
@@ -99,10 +99,17 @@ const SearchDateComponent = React.memo(
       let nextCtrlId1 = ''; // 移動先第1候補
       let nextCtrlId2 = ''; // 移動先第2候補
 
+      // 入力中フラグ(全角入力の未確定時にtrue)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const isComposing = !!(e.nativeEvent as any)?.isComposing;
+
       // 数値は半角にする
-      const value = element.value.replace(/[０-９]/g, (s) =>
-        String.fromCharCode(s.charCodeAt(0) - 0xfee0)
-      );
+      let value = element.value;
+      if (!isComposing) {
+        value = value.replace(/[０-９]/g, (s) =>
+          String.fromCharCode(s.charCodeAt(0) - 0xfee0)
+        );
+      }
 
       // Fromのテキスト欄
       if (targetId.includes('dateFromYear')) {
@@ -134,7 +141,8 @@ const SearchDateComponent = React.memo(
         value &&
         value.length === element.maxLength &&
         element.selectionStart === element.maxLength &&
-        element.selectionStart === element.selectionEnd
+        element.selectionStart === element.selectionEnd &&
+        !isComposing
       ) {
         let nextElement = nextCtrlId1
           ? document.getElementById(nextCtrlId1)
@@ -357,6 +365,9 @@ const SearchDateComponent = React.memo(
             maxLength={4}
             value={dateFromInfo.year}
             onChange={onChangeDateText}
+            onCompositionEnd={(e) => {
+              onChangeDateText(e);
+            }}
           />
           <span className="searchdate-between-text">年</span>
           {!isHiddenMonth && (
@@ -370,6 +381,9 @@ const SearchDateComponent = React.memo(
                 readOnly={isHiddenMonth}
                 value={dateFromInfo.month}
                 onChange={onChangeDateText}
+                onCompositionEnd={(e) => {
+                  onChangeDateText(e);
+                }}
               />
               <span className="searchdate-between-text">月</span>
             </>
@@ -385,6 +399,9 @@ const SearchDateComponent = React.memo(
                 readOnly={isHiddenDay}
                 value={dateFromInfo.day}
                 onChange={onChangeDateText}
+                onCompositionEnd={(e) => {
+                  onChangeDateText(e);
+                }}
               />
               <span className="searchdate-between-text">日</span>
             </>
@@ -408,6 +425,9 @@ const SearchDateComponent = React.memo(
                 maxLength={4}
                 value={dateToInfo.year}
                 onChange={onChangeDateText}
+                onCompositionEnd={(e) => {
+                  onChangeDateText(e);
+                }}
               />
               <span className="searchdate-between-text">年</span>
               {!isHiddenMonth && (
@@ -421,6 +441,9 @@ const SearchDateComponent = React.memo(
                     readOnly={isHiddenMonth}
                     value={dateToInfo.month}
                     onChange={onChangeDateText}
+                    onCompositionEnd={(e) => {
+                      onChangeDateText(e);
+                    }}
                   />
                   <span className="searchdate-between-text">月</span>
                 </>
@@ -436,6 +459,9 @@ const SearchDateComponent = React.memo(
                     readOnly={isHiddenDay}
                     value={dateToInfo.day}
                     onChange={onChangeDateText}
+                    onCompositionEnd={(e) => {
+                      onChangeDateText(e);
+                    }}
                   />
                   <span className="searchdate-between-text">日</span>
                 </>


### PR DESCRIPTION
患者一覧で初回治療開始日の検索条件を「日次」にし、IMEを全角かなにした状態で「年」を入力すると
同じ数字が連続で入ったり、「１２３４」と入れた後、月のテキストボックスに遷移し、勝手に「１２」が入る問題を修正

#### 原因
- 全角入力の場合半角に変換しているが、入力未確定状態で変換しているため？

#### 対応
以下の対応を入れたところ改善された
- 入力中(isComposing)の場合、値の変換および他コントロールへの自動フォーカス移動を行わないようにする
- onCompositionEndイベントでもonChangeDateTextを発火させ、Enterで確定後に半角へ変換するようにする