### PR TITLE
マージによってtypoが復活したため再修正

### DIFF
--- a/src/views/Patients.tsx
+++ b/src/views/Patients.tsx
@@ -336,8 +336,8 @@ const Patients = () => {
       paramValue = searchParam.get('initialTreatment');
       copySearchWord.blankFields.initialTreatment = paramValue === 'true';
       // 合併症
-      paramValue = searchParam.get('copilacations');
-      copySearchWord.blankFields.copilacations = paramValue === 'true';
+      paramValue = searchParam.get('complications');
+      copySearchWord.blankFields.complications = paramValue === 'true';
       // 3年予後
       paramValue = searchParam.get('threeYearPrognosis');
       copySearchWord.blankFields.threeYearPrognosis = paramValue === 'true';


### PR DESCRIPTION
[[誤字修正]copilacations→complications #295](https://github.com/jesgo-toitu/jesgo-frontend/pull/295/files)
で修正したtypoが
[患者一覧に戻った際に検索条件などを復元する対応 #286](https://github.com/jesgo-toitu/jesgo-frontend/pull/286)
で一部戻ってしまったため、再修正