### PR TITLE
array > stringで空行がある状態でスキーマが復元されない

### DIFF
--- a/src/components/CaseRegistration/JESGOCustomForm.tsx
+++ b/src/components/CaseRegistration/JESGOCustomForm.tsx
@@ -218,14 +218,42 @@ const CustomDivForm = (props: CustomDivFormProp) => {
           // array
           if (Array.isArray(argFormData[propName])) {
             // 削除されたarrayの項目を取り除く
-            const newArray = (argFormData[propName] as any[]).filter(
-              (p) => p != null && p !== ''
-            );
-            if (newArray.length > 0) {
-              argFormData[propName] = newArray;
+            const arrayFormData = argFormData[propName] as any[];
+            if (arrayFormData.filter((val) => val !== null && typeof val === "object").length > 0) {
+              // Arrayのitemsが複数
+              const newArrayFormData: any[] = [];
+              arrayFormData.map((formDatas: { [key: string]: any }) => {
+                const newFormDatas = { ...formDatas };
+                Object.entries(newFormDatas).forEach((data) => {
+                  const dataProp = data[0];
+                  const dataValue = data[1];
+                  if (dataValue == null) {
+                    delete newFormDatas[dataProp];
+                  }
+                })
+                if (newFormDatas != null && typeof newFormDatas === 'object' && Object.keys(newFormDatas).length > 0) {
+                  newArrayFormData.push(newFormDatas);
+                }
+              })
+
+              if (newArrayFormData.length > 0) {
+                argFormData[propName] = [...newArrayFormData];
+              } else {
+                // 表示内容が0の場合はプロパティごと削除する
+                delete argFormData[propName];
+              }
+
             } else {
-              // 表示内容が0の場合はプロパティごと削除する
-              delete argFormData[propName];
+              // Arrayのitemsが1つ
+              const newArray = (arrayFormData).filter(
+                (p) => p != null && p !== ''
+              );
+              if (newArray.length > 0) {
+                argFormData[propName] = newArray;
+              } else {
+                // 表示内容が0の場合はプロパティごと削除する
+                delete argFormData[propName];
+              }
             }
           } else if (
             ((argSchema as any)[propName] as JSONSchema7)?.properties

--- a/src/components/CaseRegistration/JESGOFieldTemplete.tsx
+++ b/src/components/CaseRegistration/JESGOFieldTemplete.tsx
@@ -137,6 +137,17 @@ export namespace JESGOFiledTemplete {
       (uiSchema['ui:description'] as string) || schema.description;
     const items = schema.items as JSONSchema7;
     const subschemastyle = items[Const.EX_VOCABULARY.UI_SUBSCHEMA_STYLE];
+    // 配列内に項目があるかどうか
+    let hasItems = false;
+    if (items != null) {
+      if (items.type === Const.JSONSchema7Types.OBJECT) {
+        if (items.properties != null && Object.keys(items.properties).length > 0) {
+          hasItems = true;
+        }
+      } else if (items.type != null) {
+        hasItems = true;
+      }
+    }
 
     // jesgo:ui:visibleWhen
     const visibleWhenCondition: VisibleWhenItem[] = [];
@@ -225,7 +236,7 @@ export namespace JESGOFiledTemplete {
         });
       }
     });
-
+   
     return (
       <div>
         {/* eslint-disable-next-line react/destructuring-assignment */}
@@ -269,13 +280,13 @@ export namespace JESGOFiledTemplete {
                 );
               })}
           </div>
-
+          
           {/* eslint-disable react/destructuring-assignment */}
           {props.canAdd && (
             <JESGOComp.AddButton
               className="array-item-add col-lg-1 col-md-1 col-sm-2 col-lg-offset-11 col-md-offset-11 col-sm-offset-10"
               onClick={props.onAddClick}
-              disabled={props.disabled || props.readonly}
+              disabled={props.disabled || props.readonly || !hasItems}
             />
           )}
           {/* eslint-enable */}


### PR DESCRIPTION
#287 の対応。
表題のバグ以外に以下も対応。

  - スキーマで配列内プロパティがない場合は、追加ボタンは押下不可とする
  - formDataからスキーマに存在しない項目を削除する処理に、Array内がobjectの場合の処理を追加
  - formDataからスキーマを復元する処理に、Array内がobjectの場合の処理を追加