### PR TITLE
dev-#355-[バグ]プラグインの保存に失敗することがある

### DIFF
--- a/src/views/PluginManager.tsx
+++ b/src/views/PluginManager.tsx
@@ -270,7 +270,7 @@ const PluginManager = () => {
       loadedJesgoPluginList.find(
         (q) => q.plugin_id === p.plugin_id && p.disabled !== q.disabled
       )
-    );
+    ).map((p) => ({ plugin_id:p.plugin_id, disabled:p.disabled } as jesgoPluginColumns));
 
     // eslint-disable-next-line no-void
     void SavePluginList(diffList).then(async (returnApiObject) => {


### PR DESCRIPTION
プラグイン保存時、plugin_idとdisabledの情報のみをバックエンドに対しpostするよう変更致しました。