### PR TITLE
jesgo:errorのハンドリング改善

### DIFF
--- a/src/components/CaseRegistration/ErrorRow.tsx
+++ b/src/components/CaseRegistration/ErrorRow.tsx
@@ -52,6 +52,10 @@ const ErrorRow = React.memo(
 
           if (patchedObj && Array.isArray(patchedObj)) {
             const validErrors = patchedObj.filter((item) => {
+              // nullは除外(objectなので最初にはじく)
+              if (item == null) {
+                return false
+              }
               // 空配列は除外
               if (Array.isArray(item)) {
                 // 配列中のnullや空白のみの要素は除外する

--- a/src/components/CaseRegistration/ErrorRow.tsx
+++ b/src/components/CaseRegistration/ErrorRow.tsx
@@ -54,7 +54,8 @@ const ErrorRow = React.memo(
             const validErrors = patchedObj.filter((item) => {
               // 空配列は除外
               if (Array.isArray(item)) {
-                return item.length > 0;
+                // 配列中のnullや空白のみの要素は除外する
+                return item.filter(value => (value.toString().trim() != '' || value != null)).length > 0;
               }
               // 空オブジェクトは除外
               if (typeof item === 'object') {


### PR DESCRIPTION
nullはバックエンド側でオブジェクトへのマッピングで生じている問題だが、フロントエンド側で対応する。
jesgo:error自体もしくは、要素にnullが含まれる場合空と判断するようにロジックを修正。