### PR TITLE
#373 ポート番号設定の外部設定化

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,29 @@
+// ライブラリ読み込み
+const fs = require("fs");
+
+// package.json読み込み
+const _pathJson = fs
+  .readFileSync('package.json')
+  .toString();
+const pathJson = JSON.parse(_pathJson);
+
+// 設定情報パス取得
+const configPath = process.env.NODE_ENV === 'production' ?
+  pathJson['config']['configPath']['production'] :
+  pathJson['config']['configPath']['development'];
+
+// 設定情報取得
+const _configJson = fs
+  .readFileSync(configPath || './dist/config.json')
+  .toString();
+const configJson = JSON.parse(_configJson);
+
+// 設定情報
+const configValues = () => {
+  return {
+    webAppPort: configJson['webApp']['webAppPort'],
+    endPointUrl: configJson['webApp']['endPointUrl'],
+  }
+}
+
+exports.default = configValues();

--- a/dist/config.json
+++ b/dist/config.json
@@ -1,5 +1,6 @@
 {
-    "config": {
+    "webApp": {
+        "webAppPort": 3030,
         "endPointUrl": "http://localhost:3000/"
     }
 }

--- a/export/export.ps1
+++ b/export/export.ps1
@@ -9,12 +9,14 @@ Remove-item .\release -Recurse -Force
 
 # ディレクトリを再生成
 New-Item release -ItemType Directory
-# ファイルコピー
-Copy-Item -Path ..\dist\ -Destination .\release\ -Recurse
+
+# ファイルコピー(設定ファイル以外)
+Copy-Item -Exclude ("config.json") -Path ..\dist\ -Destination .\release\ -Recurse
 Copy-Item -Path ..\image\ -Destination .\release\ -Recurse
 
 # その他単体ファイルをコピーする
 Copy-Item -Path ..\start.js -Destination .\release\
+Copy-Item -Path ..\config.js -Destination .\release\
 Copy-Item -Path ..\package.json -Destination .\release\
 
 # node_modules格納のためのディレクトリを作成

--- a/package.json
+++ b/package.json
@@ -3,15 +3,20 @@
   "version": "1.3",
   "description": "",
   "main": "index.js",
+  "config": {
+    "configPath": {
+      "development": "./dist/config.json",
+      "production": "../config/config.json"
+    }
+  },
   "scripts": {
-    "start": "C:\\jesgo\\node\\node-v20.18.0-win-x64\\node start.js",
-    "dev-start": "node start.js",
+    "start": "cmd /c \"if defined PATH_NODE (\"%PATH_NODE%\" start.js) else (node start.js)\"",
     "build": "webpack --progress --mode development",
     "release-build": "powershell -File ./export/export.ps1",
     "postinstall": "patch-package",
     "lint": "eslint --ext .jsx,.js,.tsx,.ts src/",
     "fmt": "prettier --write src/**/*",
-    "install-service": "winser -i",
+    "install-service": "winser -i --env \"NODE_ENV=%NODE_ENV%\" --env \"PATH_NODE=%PATH_NODE%\"",
     "uninstall-service": "winser -r -x"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     }
   },
   "scripts": {
-    "start": "cmd /c \"if defined PATH_NODE (\"%PATH_NODE%\" start.js) else (node start.js)\"",
+    "start": "cmd /c \"if defined PATH_NODE (\"\"%PATH_NODE%\"\" start.js) else (node start.js)\"",
     "build": "webpack --progress --mode development",
     "release-build": "powershell -File ./export/export.ps1",
     "postinstall": "patch-package",
     "lint": "eslint --ext .jsx,.js,.tsx,.ts src/",
     "fmt": "prettier --write src/**/*",
-    "install-service": "winser -i --env \"NODE_ENV=%NODE_ENV%\" --env \"PATH_NODE=%PATH_NODE%\"",
+    "install-service": "winser -i",
     "uninstall-service": "winser -r -x"
   },
   "keywords": [],

--- a/src/common/ApiAccess.ts
+++ b/src/common/ApiAccess.ts
@@ -2,12 +2,12 @@ import axios, { AxiosRequestConfig } from 'axios';
 
 const CONFIG_PATH = './config.json' as string;
 
-export type EndPointCOnfig = {
+export type WebApp = {
   endPointUrl: string;
 };
 
 export type Config = {
-  config: EndPointCOnfig;
+  webApp: WebApp;
 };
 
 let config: Config;
@@ -59,7 +59,7 @@ const apiAccess = async (
       config = configJson;
     })
     .catch(() => {
-      config.config.endPointUrl = 'http://localhost:3000';
+      config.webApp.endPointUrl = 'http://localhost:3000';
     });
 
   let token = localStorage.getItem('token');
@@ -96,7 +96,7 @@ const apiAccess = async (
   switch (methodType) {
     case METHOD_TYPE.GET:
       await axios
-        .get(`${config.config.endPointUrl}${url}`, payloadObj)
+        .get(`${config.webApp.endPointUrl}${url}`, payloadObj)
         .then((response) => {
           returnObj = response.data as ApiReturnObject;
         })
@@ -107,7 +107,7 @@ const apiAccess = async (
 
     case METHOD_TYPE.POST:
       await axios
-        .post(`${config.config.endPointUrl}${url}`, payloadObj)
+        .post(`${config.webApp.endPointUrl}${url}`, payloadObj)
         .then((response) => {
           returnObj = response.data as ApiReturnObject;
         })
@@ -118,7 +118,7 @@ const apiAccess = async (
 
     case METHOD_TYPE.DELETE:
       await axios
-        .delete(`${config.config.endPointUrl}${url}`, payloadObj)
+        .delete(`${config.webApp.endPointUrl}${url}`, payloadObj)
         .then((response) => {
           returnObj = response.data as ApiReturnObject;
         })
@@ -129,7 +129,7 @@ const apiAccess = async (
 
     case METHOD_TYPE.POST_ZIP:
       await axios
-        .post(`${config.config.endPointUrl}${url}`, payloadObj.data, payloadObj)
+        .post(`${config.webApp.endPointUrl}${url}`, payloadObj.data, payloadObj)
         .then((response) => {
           returnObj = response.data as ApiReturnObject;
         })
@@ -158,7 +158,7 @@ const apiAccess = async (
     const refleshToken = localStorage.getItem('reflesh_token');
     if (refleshToken !== null) {
       await axios
-        .post(`${config.config.endPointUrl}relogin/`, {
+        .post(`${config.webApp.endPointUrl}relogin/`, {
           reflesh_token: refleshToken,
         })
         .then(async (response) => {

--- a/start.js
+++ b/start.js
@@ -1,9 +1,19 @@
+// プロセス名の設定
+process.title = "JESGO-WebApp";
+
 const path = require("path");
 const express = require("express");
+const configValues = require("./config.js");
 const router = express.Router();
 
 const app = express();
-const port = process.env.PORT || 3030; // port番号を指定
+
+// ポート情報の設定
+const port = configValues.default.webAppPort || process.env.JESGO_WEBAPP_PORT || 3030;
+
+if (process.env.NODE_ENV === 'production') {
+  app.use(express.static("../config"));
+}
 
 app.use(express.static("dist"));
 app.use('/image', express.static('image'));
@@ -23,7 +33,6 @@ app.use("/", router);
 
 // サーバー起動
 app.listen(port, function () {
-  console.log(`express: start. port=${port}, mode=${app.settings.env}`);
+  console.log(`express: start. port=${port}, mode=${app.settings.env}, node=${process.execPath}`);
   console.log('JESGO Webアプリ起動中...');
 });
-


### PR DESCRIPTION
① WebApp、Serverアプリケーションの設定ファイル(config.json)を共通化して外部化する
両アプリケーションの設定項目を統合して、下記のように相対パスで参照する。
開発モード：既存のパスを参照
本番モード：../config/config.json
※配布資源の場合、rootフォルダ直下に対して上記パスに設定ファイルを配置する。
　配布資源作成スクリプト(export.ps1)にて、config.jsonを除外して資源には同梱しない。
※開発モード、本番モードの相対パスはpackage.jsonのconfigにて管理。
※WebApp側のexpressにて、提供する設定ファイルはモードによって切り替える。
※package.jsonのconfig情報は、サービス実行時(winser経由)に読み込まれないため、
　package.jsonを読み込みconfig情報を取得するよう処理を共通化。

② package.jsonのスクリプトにて、nodeの実行パスを環境変数化する
配布資源のenv.batにて、環境変数「PATH_NODE」に実行パスを設定して、
スクリプト実行時にPATH_NODEを指定してnodeを実行する。
※PATH_NODEが未定義の場合、PATH_NODEは指定せず既存通りnodeを実行。
※サービス実行時は、サービス登録時に指定したモード、node実行パスを適用。